### PR TITLE
Standardize OAUTH2_SCHEME_TOKEN_URL configuration.

### DIFF
--- a/Aletheia_v3/docker-compose.yml
+++ b/Aletheia_v3/docker-compose.yml
@@ -24,6 +24,8 @@ x-common-env: &common-env
   ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-30}
   # Database URL for Alembic and application (constructed from other POSTGRES_ vars if not set directly)
   ALETHEIA_V3_DATABASE_URL: ${ALETHEIA_V3_DATABASE_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@db:${DB_PORT:-5432}/${POSTGRES_DB:-aletheia_db}}
+  # OAuth2 Scheme Token URL for aletheia_common, should match the actual token endpoint path
+  OAUTH2_SCHEME_TOKEN_URL: ${OAUTH2_SCHEME_TOKEN_URL:-token}
 
 
 services:

--- a/aletheia_common/auth/jwt_handler.py
+++ b/aletheia_common/auth/jwt_handler.py
@@ -18,7 +18,8 @@ JWT_ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "
 # OAuth2PasswordBearer needs a tokenUrl. This should point to the actual token endpoint in the main API.
 # This might need to be configurable if different modules have different token URLs or if there's one central one.
 # For now, assume a central token URL. This will be used by FastAPI's Depends(oauth2_scheme).
-OAUTH2_SCHEME_TOKEN_URL = os.getenv("OAUTH2_SCHEME_TOKEN_URL", "/api/v1/token") # Default to a common path
+# Defaulting to "/token" as it's a common pattern for non-versioned auth endpoints.
+OAUTH2_SCHEME_TOKEN_URL = os.getenv("OAUTH2_SCHEME_TOKEN_URL", "/token")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=OAUTH2_SCHEME_TOKEN_URL)
 
 # --- Pydantic Models for Authentication Data ---

--- a/aletheia_stats/docker-compose.yml
+++ b/aletheia_stats/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - STATS_API_PORT=${STATS_API_PORT:-8001} # For Uvicorn in main.py
       - STATS_LOG_LEVEL_UVICORN=${STATS_LOG_LEVEL_UVICORN:-info} # For Uvicorn's logging
       - APP_ENVIRONMENT=${STATS_APP_ENVIRONMENT:-development}
+      # OAUTH2_SCHEME_TOKEN_URL for aletheia_common, specific to aletheia_stats's own token endpoint
+      - OAUTH2_SCHEME_TOKEN_URL=${STATS_OAUTH2_SCHEME_TOKEN_URL:-/api/v1/token}
     depends_on:
       db:
         condition: service_healthy # Wait for DB to be healthy


### PR DESCRIPTION
This commit ensures that the OAUTH2_SCHEME_TOKEN_URL used by `aletheia_common.auth.jwt_handler` is correctly configured for both the Aletheia_v3 and aletheia_stats services.

Changes include:
- Modified `aletheia_common/auth/jwt_handler.py` to default `OAUTH2_SCHEME_TOKEN_URL` to "/token".
- Updated `Aletheia_v3/docker-compose.yml` to explicitly set `OAUTH2_SCHEME_TOKEN_URL` to "token" for its api service.
- Updated `aletheia_stats/docker-compose.yml` to explicitly set `OAUTH2_SCHEME_TOKEN_URL` to "/api/v1/token" for its api service.

These changes ensure that the Swagger UI documentation for both services correctly points to their respective token endpoints for OAuth2 authorization flows.