### PR TITLE
Fix: Correct missing imports in aletheia_stats module

### DIFF
--- a/aletheia_stats/aletheia_stats/main.py
+++ b/aletheia_stats/aletheia_stats/main.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import datetime # Added import
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn

--- a/aletheia_stats/infrastructure/models.py
+++ b/aletheia_stats/infrastructure/models.py
@@ -1,4 +1,7 @@
 import uuid as uuid_pkg
+from typing import Optional, List, Dict, Any # Added import
+
+import sqlalchemy as sa # Added import
 from sqlalchemy import Column, String, Float, DateTime, Text, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column # Usando nueva sintaxis de Mapped si es posible/preferido

--- a/aletheia_stats/infrastructure/sqlalchemy_repository.py
+++ b/aletheia_stats/infrastructure/sqlalchemy_repository.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple, Any, Dict
 from uuid import UUID
 import logging
 
+from sqlalchemy import func # Added import
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 


### PR DESCRIPTION
- Add `import sqlalchemy as sa` and typing imports to `infrastructure/models.py`.
- Add `from sqlalchemy import func` to `infrastructure/sqlalchemy_repository.py`.
- Add `import datetime` to `aletheia_stats/main.py`.