### PR TITLE
feat: Implement realistic knowledge synthesis in DomainService

### DIFF
--- a/Aletheia_v3/core/domain_services.py
+++ b/Aletheia_v3/core/domain_services.py
@@ -17,7 +17,7 @@ class TheoryBuilder:
         patterns = self._identify_patterns(clusters)
         principles = self._extract_principles(patterns)
         formal_relations = self._formalize_relations(clusters)
-        validation_metrics = self._validate_theory(principles)
+        validation_metrics = self._validate_theory(principles, patterns) # Pasar patterns aquí
 
         return UnifiedTheory(
             id=f"theory_{hashlib.sha1(str(datetime.now()).encode()).hexdigest()[:8]}",
@@ -28,54 +28,138 @@ class TheoryBuilder:
         )
 
     def _identify_patterns(self, clusters: List[ConceptCluster]) -> List[Pattern]:
-        """Identificación de patrones usando análisis de grafos"""
-        if not clusters: return []
-        all_graphs = [c.graph for c in clusters if c.graph is not None and len(c.graph.nodes) > 0]
-        if not all_graphs: return []
+        """
+        Identifica patrones estructurales simples (Path y Star) en los grafos de los ConceptCluster.
 
-        motifs = self._find_common_motifs(all_graphs)
-        hierarchies = self._detect_hierarchies(all_graphs)
-        return motifs + hierarchies
+        Args:
+            clusters: Una lista de ConceptCluster, cada uno potencialmente con un grafo.
 
-    def _find_common_motifs(self, graphs: List[nx.Graph]) -> List[Pattern]:
-        # Placeholder: In reality, this would use graph algorithms to find common subgraphs/patterns
-        print(f"Domain: Finding common motifs in {len(graphs)} graphs.")
-        if not graphs: return []
-        # Example: if a specific subgraph (e.g., a triangle) is found frequently
-        # This requires actual graph analysis algorithms.
-        return [Pattern(id="motif_placeholder_1", description="Placeholder common pattern", elements=["X", "Y", "Z"])]
+        Returns:
+            Una lista de objetos Pattern representando los patrones identificados.
+        """
+        identified_patterns: List[Pattern] = []
+        if not clusters:
+            return identified_patterns
 
-    def _detect_hierarchies(self, graphs: List[nx.Graph]) -> List[Pattern]:
-        # Placeholder: Detect hierarchical structures
-        print(f"Domain: Detecting hierarchies in {len(graphs)} graphs.")
-        if not graphs: return []
-        hierarchies = []
-        for i, G in enumerate(graphs):
-            if nx.is_directed_acyclic_graph(G): # Example check, assumes graphs can be directed
-                 hierarchies.append(Pattern(id=f"hierarchy_placeholder_{i}", description="Placeholder detected hierarchy", elements=list(G.nodes())))
-        return hierarchies
+        for i, cluster in enumerate(clusters):
+            if not cluster.graph or cluster.graph.number_of_nodes() == 0:
+                continue
+
+            G = cluster.graph
+            num_nodes = G.number_of_nodes()
+
+            # Intentar identificar Path Graph
+            if nx.is_connected(G):
+                degrees = [d for n, d in G.degree()]
+                is_path_like = num_nodes >= 2 and degrees.count(1) == 2 and degrees.count(2) == num_nodes - 2
+                is_tree = nx.is_tree(G) # Un path es un tipo de árbol
+
+                if is_path_like and is_tree:
+                    pattern_id = f"pattern_path_{cluster.units[0].id if cluster.units else i}"
+                    elements_involved = list(G.nodes()) # IDs de ConceptualUnit
+                    identified_patterns.append(
+                        Pattern(id=pattern_id, description=f"Path structure identified in cluster starting with {elements_involved[0] if elements_involved else 'unknown'}", elements=elements_involved)
+                    )
+                    continue # Si es path, no puede ser estrella (para >2 nodos)
+
+                # Intentar identificar Star Graph (si no es un path)
+                if num_nodes >= 3:
+                    central_nodes = [n for n, d in G.degree() if d == num_nodes - 1]
+                    leaf_nodes = [n for n, d in G.degree() if d == 1]
+
+                    if len(central_nodes) == 1 and len(leaf_nodes) == num_nodes - 1:
+                        center_node_id = central_nodes[0]
+                        # Verificar que todas las hojas estén conectadas al centro
+                        # y que el grafo sea un árbol (una estrella es un árbol).
+                        is_star_candidate = True
+                        for leaf_node_id in leaf_nodes:
+                            if not G.has_edge(center_node_id, leaf_node_id):
+                                is_star_candidate = False
+                                break
+                        if is_star_candidate and nx.is_tree(G):
+                            pattern_id = f"pattern_star_{cluster.units[0].id if cluster.units else i}"
+                            elements_involved = list(G.nodes()) # IDs de ConceptualUnit
+                            identified_patterns.append(
+                                Pattern(id=pattern_id, description=f"Star structure identified with center {center_node_id}", elements=elements_involved)
+                            )
+        return identified_patterns
 
     def _extract_principles(self, patterns: List[Pattern]) -> List[str]:
-        # Placeholder: Extract principles from patterns
-        print(f"Domain: Extracting principles from {len(patterns)} patterns.")
-        if not patterns: return []
-        return [f"Placeholder principle derived from {p.id}" for p in patterns]
+        """
+        Extrae principios descriptivos basados en los patrones identificados.
+
+        Args:
+            patterns: Una lista de objetos Pattern.
+
+        Returns:
+            Una lista de strings, donde cada string es un principio.
+        """
+        principles: List[str] = []
+        if not patterns:
+            return principles
+
+        for pattern in patterns:
+            if "path" in pattern.id.lower():
+                principles.append(f"Principle of Linear Progression/Causality (derived from {pattern.description})")
+            elif "star" in pattern.id.lower():
+                principles.append(f"Principle of Centralized Influence/Convergence (derived from {pattern.description})")
+            else:
+                principles.append(f"General Structural Principle (derived from {pattern.description})")
+        return principles
 
     def _formalize_relations(self, clusters: List[ConceptCluster]) -> Dict[str, List[str]]:
-        # Placeholder: Formalize relations between cluster elements
-        print(f"Domain: Formalizing relations for {len(clusters)} clusters.")
-        if not clusters: return {}
-        relations = {}
-        for i, cluster in enumerate(clusters):
-            if cluster.units:
-                cluster_id_key = cluster.units[0].id if cluster.units else f"cluster_placeholder_{i}"
-                relations[cluster_id_key] = [u.id for u in cluster.units[1:4]] # Take a few related IDs
+        """
+        Formaliza las relaciones dentro de cada clúster.
+
+        Para cada clúster, toma el ID de la primera unidad conceptual como clave
+        y una lista de los IDs de las unidades restantes como valor.
+
+        Args:
+            clusters: Una lista de ConceptCluster.
+
+        Returns:
+            Un diccionario representando las relaciones formalizadas.
+        """
+        relations: Dict[str, List[str]] = {}
+        if not clusters:
+            return relations
+
+        for cluster in clusters:
+            if cluster.units and len(cluster.units) > 0:
+                key_concept_id = cluster.units[0].id
+                related_concept_ids = [unit.id for unit in cluster.units[1:]]
+
+                if related_concept_ids:
+                    relations[key_concept_id] = related_concept_ids
         return relations
 
-    def _validate_theory(self, principles: List[str]) -> Dict[str, float]:
-        # Placeholder: Validate the synthesized theory
-        print(f"Domain: Validating theory with {len(principles)} principles.")
-        return {"consistency_placeholder": 0.90, "completeness_placeholder": 0.80} if principles else {}
+    def _validate_theory(self, principles: List[str], patterns: List[Pattern]) -> Dict[str, float]:
+        """
+        Calcula métricas de validación para una teoría basada en sus principios y patrones.
+
+        Args:
+            principles: Lista de principios de la teoría.
+            patterns: Lista de patrones identificados en la teoría.
+
+        Returns:
+            Un diccionario con métricas de validación, como 'consistency_score'.
+        """
+        num_principles = len(principles)
+        num_patterns = len(patterns)
+        consistency = 0.0
+
+        if num_principles > 0 and num_patterns > 0:
+            # Asumimos que cada principio generado por _extract_principles se basa en un patrón.
+            consistency = 1.0
+        elif num_principles == 0 and num_patterns == 0:
+            consistency = 1.0 # Vacuamente consistente.
+
+        validation_metrics = {
+            "consistency_score": consistency,
+            "num_derived_principles": float(num_principles),
+            "num_identified_patterns": float(num_patterns)
+        }
+        return validation_metrics
 
 # Note: The original mdu_cube_system.py also had a DomainService class.
 # That class was more of an application service as it orchestrated calls to TheoryBuilder
@@ -95,6 +179,7 @@ class TheoryBuilder:
 # and its methods (extract_atomic_units, etc.) are domain-focused operations.
 
 import numpy as np # For ConceptualUnit embeddings in DomainService placeholders
+import uuid # Para IDs únicos
 # from .domain_models import ConceptualUnit, ConceptCluster, UnifiedTheory # Relative import - Now covered by the top import
 
 class DomainService: # This was in mdu_cube_system.py, fits here as it uses TheoryBuilder
@@ -102,7 +187,7 @@ class DomainService: # This was in mdu_cube_system.py, fits here as it uses Theo
         self.theory_builder = theory_builder
 
     async def extract_atomic_units(self, session_data: str) -> List[ConceptualUnit]:
-        print(f"DomainService: Extracting atomic units from data of length {len(session_data)}")
+        # print(f"DomainService: Extracting atomic units from data of length {len(session_data)}") # Placeholder
         # Placeholder: Create some dummy conceptual units
         return [
             ConceptualUnit(id="ds_unit1", content="First concept from DS", embeddings=np.random.rand(10), relations={"ds_unit2"}, metadata={"source":"docA_ds"}),
@@ -110,62 +195,128 @@ class DomainService: # This was in mdu_cube_system.py, fits here as it uses Theo
         ]
 
     async def form_clusters(self, atoms: List[ConceptualUnit]) -> List[ConceptCluster]:
-        print(f"DomainService: Forming clusters from {len(atoms)} atomic units.")
+        # print(f"DomainService: Forming clusters from {len(atoms)} atomic units.") # Placeholder
         if not atoms: return []
         # Placeholder: Simple clustering
         return [ConceptCluster(atoms)] if atoms else []
 
     async def build_mini_theories(self, clusters: List[ConceptCluster]) -> List[UnifiedTheory]:
-        print(f"DomainService: Building mini-theories from {len(clusters)} clusters.")
-        if not clusters: return []
+        """
+        Construye una lista de "mini-teorías", una para cada clúster de conceptos.
+
+        Utiliza el TheoryBuilder para sintetizar una UnifiedTheory para cada clúster.
+        El ID de cada mini-teoría es generado por el TheoryBuilder.
+
+        Args:
+            clusters: Una lista de ConceptCluster.
+
+        Returns:
+            Una lista de objetos UnifiedTheory, cada uno representando una mini-teoría.
+        """
+        # print(f"DomainService: Building mini-theories from {len(clusters)} clusters.") # Placeholder
+        if not clusters:
+            return []
         mini_theories = []
-        for i, cluster in enumerate(clusters):
+        for cluster in clusters: # No need for index 'i' if not used for ID
+            # ID de la teoría ya es asignado unívocamente por self.theory_builder.synthesize_theory
             theory = self.theory_builder.synthesize_theory([cluster])
-            theory.id = f"ds_mini_theory_{cluster.units[0].id if cluster.units else i}"
             mini_theories.append(theory)
         return mini_theories
 
     async def synthesize_model(self, theories: List[UnifiedTheory]) -> UnifiedTheory:
-        print(f"DomainService: Synthesizing unified model from {len(theories)} mini-theories.")
+        """
+        Sintetiza un modelo unificado a partir de una lista de mini-teorías.
+
+        El modelo unificado agrega los patrones, principios y relaciones de todas
+        las mini-teorías de entrada. Los principios se hacen únicos. Las relaciones
+        se fusionan, y las listas de conceptos relacionados para una misma clave
+        también se hacen únicas. Las métricas de validación numéricas se promedian.
+        Se genera un nuevo ID único para el modelo unificado.
+
+        Args:
+            theories: Una lista de UnifiedTheory (mini-teorías).
+
+        Returns:
+            Un único objeto UnifiedTheory que representa el modelo agregado.
+        """
+        # print(f"DomainService: Synthesizing unified model from {len(theories)} mini-theories.") # Placeholder
+
+        unified_model_id = f"unified_model_{uuid.uuid4().hex[:8]}"
+
         if not theories:
-            return UnifiedTheory(id="ds_empty_unified_model", patterns=[], principles=[], relations={}, validation_metrics={})
+            return UnifiedTheory(id=unified_model_id, patterns=[], principles=[], relations={}, validation_metrics={})
 
-        if theories:
-            all_patterns = []
-            all_principles = []
-            all_relations = {}
-            unified_id = f"ds_unified_model_{theories[0].id}" if theories else "ds_unified_model_default"
+        all_patterns: List[Pattern] = []
+        all_principles_set: set[str] = set()
+        all_relations: Dict[str, List[str]] = {}
 
-            for theory in theories:
-                all_patterns.extend(theory.patterns)
-                all_principles.extend(theory.principles)
-                for k, v in theory.relations.items():
-                    if k not in all_relations: all_relations[k] = []
-                    all_relations[k].extend(v)
+        summed_metrics: Dict[str, float] = {}
+        metric_counts: Dict[str, int] = {}
 
-            # Remove duplicates by converting to set of tuples (for dicts in patterns) then back to list
-            # This is a bit simplistic for Pattern objects, assuming they are hashable or have unique IDs.
-            # A more robust deduplication might be needed.
-            # For now, rely on Pattern IDs being unique if deduplication of Pattern objects is critical.
-            # Or, if patterns are simple dicts after __dict__:
-            # unique_patterns_dict = {json.dumps(p.__dict__, sort_keys=True): p for p in all_patterns}
-            # all_patterns = list(unique_patterns_dict.values())
+        for theory in theories:
+            all_patterns.extend(theory.patterns)
+            for principle in theory.principles:
+                all_principles_set.add(principle)
 
+            for key, value_list in theory.relations.items():
+                if key not in all_relations:
+                    all_relations[key] = []
+                # Evitar duplicados dentro de la lista de relaciones para una misma clave
+                for item in value_list:
+                    if item not in all_relations[key]:
+                        all_relations[key].append(item)
 
-            unified_model = UnifiedTheory(
-                id=unified_id,
-                patterns=all_patterns, # Simplistic combination
-                principles=list(set(all_principles)),
-                relations=all_relations,
-                validation_metrics={"ds_combined_consistency": 0.88}
-            )
-            return unified_model
-        return UnifiedTheory(id="ds_default_unified_model", patterns=[], principles=[], relations={}, validation_metrics={})
+            for metric_key, metric_value in theory.validation_metrics.items():
+                if isinstance(metric_value, (int, float)): # Solo promediar numéricos
+                    summed_metrics[metric_key] = summed_metrics.get(metric_key, 0.0) + metric_value
+                    metric_counts[metric_key] = metric_counts.get(metric_key, 0) + 1
+
+        averaged_metrics: Dict[str, float] = {}
+        for key, total_sum in summed_metrics.items():
+            count = metric_counts.get(key, 0)
+            if count > 0:
+                averaged_metrics[key] = total_sum / count
+
+        # Por ahora, simple concatenación de patrones. La unicidad de patrones podría manejarse
+        # si Pattern.id fuera un identificador único fiable para la deduplicación.
+        final_patterns = all_patterns
+        final_principles = list(all_principles_set)
+
+        unified_model = UnifiedTheory(
+            id=unified_model_id,
+            patterns=final_patterns,
+            principles=final_principles,
+            relations=all_relations,
+            validation_metrics=averaged_metrics
+        )
+        return unified_model
 
     def calculate_metrics(self, unified_model: UnifiedTheory) -> Dict[str, float]:
-        print(f"DomainService: Calculating metrics for model {unified_model.id}")
-        return {
-            "ds_num_patterns": len(unified_model.patterns),
-            "ds_num_principles": len(unified_model.principles),
-            **unified_model.validation_metrics
+        """
+        Calcula métricas adicionales para un modelo unificado.
+
+        Estas métricas son sobre la estructura general del modelo unificado,
+        como el número total de patrones, principios y claves de relación.
+        Se combinan con las `validation_metrics` existentes en el modelo
+        (que, si el modelo fue sintetizado, representan promedios de mini-teorías).
+
+        Args:
+            unified_model: El objeto UnifiedTheory para el cual calcular métricas.
+
+        Returns:
+            Un diccionario de métricas combinadas.
+        """
+        # print(f"DomainService: Calculating metrics for model {unified_model.id}") # Placeholder
+
+        calculated_overall_metrics = {
+            "overall_num_patterns": float(len(unified_model.patterns)),
+            "overall_num_principles": float(len(unified_model.principles)),
+            "overall_num_relation_keys": float(len(unified_model.relations)),
         }
+        # Combinar con las métricas de validación ya existentes en el modelo.
+        # Las claves en calculated_overall_metrics podrían sobrescribir las de validation_metrics
+        # si hay colisión, aunque aquí se nombran para ser distintas ('overall_').
+        final_metrics = {**unified_model.validation_metrics, **calculated_overall_metrics}
+        return final_metrics
+# Este fragmento final de "**unified_model.validation_metrics" estaba duplicado y causaba error de sintaxis.
+# Lo he eliminado de la segunda posición. La fusión correcta es la que está en final_metrics.

--- a/Aletheia_v3/tests/unit/test_domain_services.py
+++ b/Aletheia_v3/tests/unit/test_domain_services.py
@@ -1,0 +1,279 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import networkx as nx
+import uuid
+
+from Aletheia_v3.core.domain_services import TheoryBuilder, DomainService
+from Aletheia_v3.core.domain_models import ConceptCluster, ConceptualUnit, Pattern, UnifiedTheory
+
+# --- Fixtures ---
+
+@pytest.fixture
+def theory_builder_instance():
+    """Returns a TheoryBuilder instance."""
+    return TheoryBuilder()
+
+@pytest.fixture
+def mock_theory_builder():
+    """Returns a MagicMock for TheoryBuilder."""
+    return MagicMock(spec=TheoryBuilder)
+
+@pytest.fixture
+def domain_service_instance(mock_theory_builder):
+    """Returns a DomainService instance with a mocked TheoryBuilder."""
+    return DomainService(theory_builder=mock_theory_builder)
+
+# --- Helper Functions for Creating Test Data ---
+
+def create_conceptual_unit(id_suffix: str, content: str = "content") -> ConceptualUnit:
+    return ConceptualUnit(id=f"unit_{id_suffix}", content=content, embeddings=MagicMock(), relations=set(), metadata={})
+
+def create_concept_cluster(units: List[ConceptualUnit], graph: nx.Graph = None) -> ConceptCluster:
+    cluster = ConceptCluster(units=units)
+    if graph:
+        cluster.graph = graph
+    else: # Crear un grafo simple si no se provee
+        g = nx.Graph()
+        if units:
+            for unit in units:
+                g.add_node(unit.id) # Asumimos que el ID de la unidad es el nodo del grafo
+            if len(units) > 1:
+                for i in range(len(units) - 1):
+                    g.add_edge(units[i].id, units[i+1].id)
+        cluster.graph = g
+    return cluster
+
+# --- Tests for TheoryBuilder ---
+
+class TestTheoryBuilder:
+
+    def test_identify_patterns_empty(self, theory_builder_instance: TheoryBuilder):
+        assert theory_builder_instance._identify_patterns([]) == []
+        cluster_no_graph = MagicMock(spec=ConceptCluster)
+        cluster_no_graph.graph = None
+        assert theory_builder_instance._identify_patterns([cluster_no_graph]) == []
+
+        cluster_empty_graph = MagicMock(spec=ConceptCluster)
+        empty_g = nx.Graph()
+        cluster_empty_graph.graph = empty_g
+        assert theory_builder_instance._identify_patterns([cluster_empty_graph]) == []
+
+    def test_identify_patterns_path(self, theory_builder_instance: TheoryBuilder):
+        u1, u2, u3 = create_conceptual_unit("p1"), create_conceptual_unit("p2"), create_conceptual_unit("p3")
+        path_graph = nx.Graph()
+        path_graph.add_nodes_from([u1.id, u2.id, u3.id])
+        path_graph.add_edges_from([(u1.id, u2.id), (u2.id, u3.id)])
+        cluster = create_concept_cluster(units=[u1, u2, u3], graph=path_graph)
+
+        patterns = theory_builder_instance._identify_patterns([cluster])
+        assert len(patterns) == 1
+        assert "path" in patterns[0].id.lower()
+        assert patterns[0].description.startswith("Path structure identified")
+        assert set(patterns[0].elements) == {u1.id, u2.id, u3.id}
+
+    def test_identify_patterns_star(self, theory_builder_instance: TheoryBuilder):
+        center = create_conceptual_unit("center")
+        l1, l2, l3 = create_conceptual_unit("l1"), create_conceptual_unit("l2"), create_conceptual_unit("l3")
+        star_graph = nx.Graph()
+        star_graph.add_nodes_from([center.id, l1.id, l2.id, l3.id])
+        star_graph.add_edges_from([(center.id, l1.id), (center.id, l2.id), (center.id, l3.id)])
+        cluster = create_concept_cluster(units=[center, l1, l2, l3], graph=star_graph)
+
+        patterns = theory_builder_instance._identify_patterns([cluster])
+        assert len(patterns) == 1
+        assert "star" in patterns[0].id.lower()
+        assert f"center {center.id}" in patterns[0].description
+        assert set(patterns[0].elements) == {center.id, l1.id, l2.id, l3.id}
+
+    def test_identify_patterns_no_specific_pattern(self, theory_builder_instance: TheoryBuilder):
+        # Grafo que no es ni path ni estrella simple (e.g., un ciclo o un grafo más denso)
+        u1, u2, u3, u4 = create_conceptual_unit("c1"), create_conceptual_unit("c2"), create_conceptual_unit("c3"), create_conceptual_unit("c4")
+        cycle_graph = nx.Graph()
+        cycle_graph.add_nodes_from([u1.id, u2.id, u3.id, u4.id])
+        cycle_graph.add_edges_from([(u1.id, u2.id), (u2.id, u3.id), (u3.id, u4.id), (u4.id, u1.id)]) # Ciclo de 4
+        cluster = create_concept_cluster(units=[u1,u2,u3,u4], graph=cycle_graph)
+
+        patterns = theory_builder_instance._identify_patterns([cluster])
+        assert len(patterns) == 0 # La lógica actual solo identifica paths y estrellas
+
+
+    def test_extract_principles(self, theory_builder_instance: TheoryBuilder):
+        path_pattern = Pattern(id="pattern_path_test", description="Path test desc", elements=[])
+        star_pattern = Pattern(id="pattern_star_test", description="Star test desc", elements=[])
+        other_pattern = Pattern(id="pattern_other_test", description="Other test desc", elements=[])
+
+        principles = theory_builder_instance._extract_principles([path_pattern, star_pattern, other_pattern])
+        assert len(principles) == 3
+        assert "Principle of Linear Progression/Causality (derived from Path test desc)" in principles
+        assert "Principle of Centralized Influence/Convergence (derived from Star test desc)" in principles
+        assert "General Structural Principle (derived from Other test desc)" in principles
+
+        assert theory_builder_instance._extract_principles([]) == []
+
+    def test_formalize_relations(self, theory_builder_instance: TheoryBuilder):
+        u1, u2, u3 = create_conceptual_unit("r1"), create_conceptual_unit("r2"), create_conceptual_unit("r3")
+        cluster1 = create_concept_cluster(units=[u1, u2, u3]) # Grafo por defecto se crea
+
+        u4 = create_conceptual_unit("r4")
+        cluster2 = create_concept_cluster(units=[u4]) # Un solo nodo
+
+        cluster3 = create_concept_cluster(units=[]) # Vacío
+
+        relations = theory_builder_instance._formalize_relations([cluster1, cluster2, cluster3])
+
+        assert u1.id in relations
+        assert set(relations[u1.id]) == {u2.id, u3.id}
+        assert u4.id not in relations # No hay otros conceptos para relacionar
+        assert len(relations) == 1
+
+        assert theory_builder_instance._formalize_relations([]) == {}
+
+
+    def test_validate_theory(self, theory_builder_instance: TheoryBuilder):
+        patterns = [Pattern(id="p1", description="d1", elements=[])]
+        principles = ["principle from p1"]
+        metrics = theory_builder_instance._validate_theory(principles, patterns)
+        assert metrics["consistency_score"] == 1.0
+        assert metrics["num_derived_principles"] == 1.0
+        assert metrics["num_identified_patterns"] == 1.0
+
+        metrics_no_patterns = theory_builder_instance._validate_theory(principles, [])
+        assert metrics_no_patterns["consistency_score"] == 0.0 # No hay patrones para apoyar los principios
+
+        metrics_no_principles = theory_builder_instance._validate_theory([], patterns)
+        assert metrics_no_principles["consistency_score"] == 0.0 # No hay principios para ser consistentes
+
+        metrics_empty_all = theory_builder_instance._validate_theory([], [])
+        assert metrics_empty_all["consistency_score"] == 1.0 # Vacuamente consistente
+
+
+# --- Tests for DomainService ---
+
+class TestDomainService:
+
+    @pytest.mark.asyncio
+    async def test_build_mini_theories_ids(self, domain_service_instance: DomainService, mock_theory_builder: MagicMock):
+        # Asegurar que synthesize_theory devuelve un ID único cada vez
+        # Esto ya lo hace el TheoryBuilder real usando hash(datetime)
+        # Aquí podemos simularlo o confiar en la implementación real si no se mockea profundamente.
+
+        mock_theory_output1 = UnifiedTheory(id="theory_abc", patterns=[], principles=[], relations={}, validation_metrics={})
+        mock_theory_output2 = UnifiedTheory(id="theory_def", patterns=[], principles=[], relations={}, validation_metrics={})
+
+        # Si TheoryBuilder.synthesize_theory es mockeado, necesitamos controlar su side_effect
+        mock_theory_builder.synthesize_theory.side_effect = [mock_theory_output1, mock_theory_output2]
+
+        u1, u2 = create_conceptual_unit("c1"), create_conceptual_unit("c2")
+        cluster1 = create_concept_cluster(units=[u1])
+        cluster2 = create_concept_cluster(units=[u2])
+
+        mini_theories = await domain_service_instance.build_mini_theories([cluster1, cluster2])
+
+        assert len(mini_theories) == 2
+        # Verifica que los IDs son los que el mock_theory_builder.synthesize_theory devolvió
+        assert mini_theories[0].id == "theory_abc"
+        assert mini_theories[1].id == "theory_def"
+        # O, para mayor robustez, que los IDs son diferentes
+        assert mini_theories[0].id != mini_theories[1].id
+
+
+    @pytest.mark.asyncio
+    async def test_synthesize_model_empty_theories(self, domain_service_instance: DomainService):
+        result = await domain_service_instance.synthesize_model([])
+        assert isinstance(result, UnifiedTheory)
+        assert len(result.patterns) == 0
+        assert len(result.principles) == 0
+        assert len(result.relations) == 0
+        assert len(result.validation_metrics) == 0
+        assert result.id.startswith("unified_model_")
+
+    @pytest.mark.asyncio
+    async def test_synthesize_model_aggregation(self, domain_service_instance: DomainService):
+        t1_patterns = [Pattern(id="p1", description="d1", elements=["e1"])]
+        t1_principles = ["prin1", "common_prin"]
+        t1_relations = {"unit_a": ["unit_b"], "common_key": ["rel1"]}
+        t1_metrics = {"metric1": 1.0, "common_metric": 0.5, "metric_str": "info"} # metric_str no se promediará
+
+        t2_patterns = [Pattern(id="p2", description="d2", elements=["e2"]), Pattern(id="p3", description="d3", elements=["e3"])]
+        t2_principles = ["prin2", "common_prin"]
+        t2_relations = {"unit_c": ["unit_d"], "common_key": ["rel2"]}
+        t2_metrics = {"metric1": 0.8, "common_metric": 0.7, "metric2": 0.9}
+
+        theory1 = UnifiedTheory(id="t1", patterns=t1_patterns, principles=t1_principles, relations=t1_relations, validation_metrics=t1_metrics)
+        theory2 = UnifiedTheory(id="t2", patterns=t2_patterns, principles=t2_principles, relations=t2_relations, validation_metrics=t2_metrics)
+
+        result = await domain_service_instance.synthesize_model([theory1, theory2])
+
+        assert result.id.startswith("unified_model_")
+
+        # Patterns: concatenación simple
+        assert len(result.patterns) == 3
+        assert result.patterns[0].id == "p1"
+        assert result.patterns[1].id == "p2"
+        assert result.patterns[2].id == "p3"
+
+        # Principles: concatenación con unicidad
+        assert len(result.principles) == 3
+        assert "prin1" in result.principles
+        assert "prin2" in result.principles
+        assert "common_prin" in result.principles
+
+        # Relations: fusión, listas de valores concatenadas y únicas
+        assert len(result.relations) == 3
+        assert "unit_a" in result.relations and result.relations["unit_a"] == ["unit_b"]
+        assert "unit_c" in result.relations and result.relations["unit_c"] == ["unit_d"]
+        assert "common_key" in result.relations and set(result.relations["common_key"]) == {"rel1", "rel2"}
+
+        # Validation Metrics: promedio de las numéricas
+        assert len(result.validation_metrics) == 3 # metric1, common_metric, metric2 (metric_str ignorada)
+        assert result.validation_metrics["metric1"] == pytest.approx((1.0 + 0.8) / 2)
+        assert result.validation_metrics["common_metric"] == pytest.approx((0.5 + 0.7) / 2)
+        assert result.validation_metrics["metric2"] == pytest.approx(0.9 / 1) # Solo en t2
+
+    @pytest.mark.asyncio
+    async def test_synthesize_model_single_theory(self, domain_service_instance: DomainService):
+        # Similar a aggregation pero con una sola teoría
+        t1_patterns = [Pattern(id="p_single", description="d_single", elements=["e_s"])]
+        t1_principles = ["prin_single"]
+        t1_relations = {"unit_s": ["unit_s_rel"]}
+        t1_metrics = {"metric_s": 0.77}
+        theory1 = UnifiedTheory(id="t_single", patterns=t1_patterns, principles=t1_principles, relations=t1_relations, validation_metrics=t1_metrics)
+
+        result = await domain_service_instance.synthesize_model([theory1])
+
+        assert result.id.startswith("unified_model_")
+        assert result.patterns == t1_patterns
+        assert result.principles == t1_principles
+        assert result.relations == t1_relations
+        assert result.validation_metrics == t1_metrics
+
+
+    def test_calculate_metrics(self, domain_service_instance: DomainService):
+        model_metrics = {"consistency_score": 0.8, "num_patterns": 5.0} # Estas serían las promediadas
+        model = UnifiedTheory(
+            id="test_model",
+            patterns=[MagicMock() for _ in range(3)], # 3 patrones
+            principles=["p1", "p2"], # 2 principios
+            relations={"k1": ["v1"], "k2": ["v2", "v3"]}, # 2 claves de relación
+            validation_metrics=model_metrics.copy()
+        )
+
+        calculated = domain_service_instance.calculate_metrics(model)
+
+        assert calculated["overall_num_patterns"] == 3.0
+        assert calculated["overall_num_principles"] == 2.0
+        assert calculated["overall_num_relation_keys"] == 2.0
+        # Asegurar que las métricas originales de validation_metrics se conservan
+        # y se combinan con las nuevas 'overall'
+        assert calculated["consistency_score"] == 0.8
+        # assert calculated["num_patterns"] == 5.0 # Esta clave no debería estar si no está en model_metrics
+
+        # Verificar que todas las claves de model_metrics están en calculated
+        for k,v in model_metrics.items():
+            assert calculated[k] == v
+
+        # Verificar que las claves 'overall' están presentes
+        assert "overall_num_patterns" in calculated
+        assert "overall_num_principles" in calculated
+        assert "overall_num_relation_keys" in calculated
+```


### PR DESCRIPTION
Implements more realistic knowledge synthesis logic:

TheoryBuilder:
- _identify_patterns now uses graph properties (degree, connectivity, is_tree) to identify simple path-like and star-like patterns from ConceptCluster graphs.
- _extract_principles derives textual principles based on the type and description of identified patterns.
- _formalize_relations creates a dictionary of relationships from cluster members.
- _validate_theory computes a basic consistency score and counts of patterns/principles.

DomainService:
- build_mini_theories now relies on TheoryBuilder for unique mini-theory IDs.
- synthesize_model aggregates multiple UnifiedTheory inputs by:
  - Concatenating patterns.
  - Concatenating principles with uniqueness.
  - Merging relation dictionaries, ensuring unique related items per key.
  - Averaging numerical validation_metrics from mini-theories.
  - Generating a unique ID for the resulting unified model.
- calculate_metrics computes overall structural metrics and combines them with existing validation_metrics.
- Placeholder prints have been commented out.

Unit Tests:
- Added comprehensive unit tests in test_domain_services.py for the new logic in TheoryBuilder and DomainService, covering pattern identification, principle extraction, relation formalization, theory validation, and model synthesis/aggregation.