### PR TITLE
feat: Implement functional API visualization endpoints

### DIFF
--- a/Aletheia_v3/api/routers/knowledge_synthesis_router.py
+++ b/Aletheia_v3/api/routers/knowledge_synthesis_router.py
@@ -221,7 +221,12 @@ async def unified_models_endpoint(
 # --- Endpoints de Visualización del Eje Y ---
 from ..schemas import HierarchyGraphResponseSchema, SynthesisStatisticsResponseSchema # Nuevos Schemas
 # (IConceptRepository y dependencias ya importados)
-# from ...core.domain_models import ConceptType # Para generar datos de ejemplo
+from ...application.ports import IConceptRepository # Asegurar que esté importado
+from ...core.domain_models import ConceptType # Para lógica interna
+from ..dependencies import get_concept_repository # Para la dependencia
+from fastapi import Query # Nueva importación
+from collections import deque # Para BFS
+from typing import List, Dict, Optional, Any # Para tipos internos
 
 @router.get(
     "/visualization/hierarchy_graph/{concept_id}",
@@ -231,31 +236,106 @@ from ..schemas import HierarchyGraphResponseSchema, SynthesisStatisticsResponseS
 )
 async def get_hierarchy_graph(
     concept_id: str,
-    # concept_repo: IConceptRepository = Depends(get_concept_repository) # Para implementación real
+    max_depth: Optional[int] = Query(3, ge=1, le=5, description="Profundidad máxima de la jerarquía a explorar."),
+    concept_repo: IConceptRepository = Depends(get_concept_repository)
 ):
     """
     Devuelve los nodos y aristas para construir un grafo de jerarquía
     para un concepto de alto nivel (ej. Modelo Unificado, Teoría Comprehensiva).
-    Por ahora, devuelve datos simulados.
+    Explora los conceptos miembro recursivamente hasta la profundidad especificada.
     """
-    # TODO: Implementar lógica real para construir el grafo de jerarquía
-    #       consultando el concept_repo y relationship_repo.
-    #       Se necesitaría recorrer las propiedades "member_..." recursivamente.
-    if concept_id == "unifiedm_placeholder_0" or concept_id.startswith("unifiedm_"): # Simular para un ID conocido
-        nodes = [
-            HierarchyGraphNodeSchema(id=concept_id, label=f"Modelo Unificado ({concept_id[:6]})", type="UNIFIED_MODEL", level=0),
-            HierarchyGraphNodeSchema(id="compth_1", label="Teoría Comp. 1", type="COMPREHENSIVE_THEORY", level=1),
-            HierarchyGraphNodeSchema(id="minit_a", label="Mini-Teoría A", type="MINI_THEORY", level=2),
-            HierarchyGraphNodeSchema(id="prop_x", label="Proposición X", type="PROPOSITION", level=3),
-        ]
-        edges = [
-            HierarchyGraphEdgeSchema(from_node=concept_id, to_node="compth_1", label="compuesto_de"),
-            HierarchyGraphEdgeSchema(from_node="compth_1", to_node="minit_a", label="compuesto_de"),
-            HierarchyGraphEdgeSchema(from_node="minit_a", to_node="prop_x", label="basado_en"),
-        ]
-        return HierarchyGraphResponseSchema(nodes=nodes, edges=edges)
+    root_concept = await concept_repo.get_by_id(concept_id)
+    if not root_concept:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Concepto raíz con ID '{concept_id}' no encontrado.")
 
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Concepto con ID '{concept_id}' no encontrado o no es un modelo/teoría visualizable en jerarquía (simulado).")
+    nodes_map: Dict[str, HierarchyGraphNodeSchema] = {}
+    edges: List[HierarchyGraphEdgeSchema] = []
+
+    queue = deque([(root_concept, 0)]) # (concepto_dominio, nivel_actual)
+    # visited_ids se usa para controlar los nodos que se añaden a la cola del BFS,
+    # no necesariamente los que ya están en nodes_map, ya que un nodo puede ser
+    # añadido a nodes_map como target de una arista antes de ser procesado él mismo.
+    ids_in_bfs_queue_or_processed = {root_concept.id}
+
+
+    while queue:
+        current_concept_domain, level = queue.popleft()
+
+        if current_concept_domain.id not in nodes_map:
+            nodes_map[current_concept_domain.id] = HierarchyGraphNodeSchema(
+                id=current_concept_domain.id,
+                label=current_concept_domain.name,
+                title=f"Nombre: {current_concept_domain.name}\nTipo: {current_concept_domain.concept_type.value}\nID: {current_concept_domain.id}",
+                type=current_concept_domain.concept_type.value,
+                level=level
+            )
+        else:
+            # Si el nodo ya existe (añadido como target de una arista), actualizar su nivel si este es menor
+            if nodes_map[current_concept_domain.id].level is None or level < nodes_map[current_concept_domain.id].level:
+                nodes_map[current_concept_domain.id].level = level
+
+
+        if level >= max_depth:
+            continue
+
+        member_ids_property_key: Optional[str] = None
+        edge_label = "contiene"
+
+        # Mapeo de tipos de concepto a la clave de propiedad que contiene sus miembros
+        type_to_member_key_map = {
+            ConceptType.CLUSTER: "member_concept_ids",
+            ConceptType.PROPOSITION: "involved_ucm_ids", # O podría ser based_on_cluster_id si es singular
+            ConceptType.MINI_THEORY: "member_proposition_ids",
+            ConceptType.COMPREHENSIVE_THEORY: "member_mini_theory_ids",
+            ConceptType.UNIFIED_MODEL: "member_comprehensive_theory_ids",
+        }
+        # Mapeo de etiquetas de aristas (opcional, para mayor claridad)
+        edge_labels_map = {
+            ConceptType.CLUSTER: "agrupa_ucm",
+            ConceptType.PROPOSITION: "involucra_ucm",
+            ConceptType.MINI_THEORY: "compuesto_de_prop",
+            ConceptType.COMPREHENSIVE_THEORY: "compuesto_de_minit",
+            ConceptType.UNIFIED_MODEL: "compuesto_de_compth",
+        }
+
+        member_ids_property_key = type_to_member_key_map.get(current_concept_domain.concept_type)
+        edge_label = edge_labels_map.get(current_concept_domain.concept_type, "relacionado_con")
+
+        if member_ids_property_key and member_ids_property_key in current_concept_domain.properties:
+            member_ids = current_concept_domain.properties[member_ids_property_key]
+
+            if isinstance(member_ids, list): # Asegurarse de que es una lista de IDs
+                for member_id in member_ids:
+                    # Añadir arista primero
+                    edges.append(HierarchyGraphEdgeSchema(
+                        from_node=current_concept_domain.id,
+                        to_node=member_id,
+                        label=edge_label
+                    ))
+
+                    # Añadir nodo miembro a la cola si no ha sido procesado/encolado y obtenerlo
+                    if member_id not in ids_in_bfs_queue_or_processed:
+                        member_concept_domain = await concept_repo.get_by_id(member_id)
+                        if member_concept_domain:
+                            ids_in_bfs_queue_or_processed.add(member_id)
+                            queue.append((member_concept_domain, level + 1))
+                            # Pre-añadir nodo a nodes_map para asegurar que exista para futuras aristas
+                            if member_id not in nodes_map:
+                                nodes_map[member_id] = HierarchyGraphNodeSchema(
+                                    id=member_concept_domain.id,
+                                    label=member_concept_domain.name,
+                                    title=f"Nombre: {member_concept_domain.name}\nTipo: {member_concept_domain.concept_type.value}\nID: {member_concept_domain.id}",
+                                    type=member_concept_domain.concept_type.value,
+                                    level=level + 1 # Nivel tentativo, podría actualizarse si se alcanza por un camino más corto
+                                )
+            # Manejar caso especial como 'based_on_cluster_id' que podría ser un solo ID
+            elif isinstance(member_ids, str) and member_ids_property_key == "involved_ucm_ids": # Ejemplo si fuera un solo id
+                 # Esta parte es un ejemplo, la propiedad involved_ucm_ids ya es una lista
+                 pass
+
+
+    return HierarchyGraphResponseSchema(nodes=list(nodes_map.values()), edges=edges)
+
 
 @router.get(
     "/visualization/synthesis_statistics",
@@ -264,30 +344,41 @@ async def get_hierarchy_graph(
     dependencies=[Depends(require_roles(["researcher", "admin"]))],
 )
 async def get_synthesis_statistics(
-    # concept_repo: IConceptRepository = Depends(get_concept_repository) # Para implementación real
+    concept_repo: IConceptRepository = Depends(get_concept_repository),
+    relationship_repo: IRelationshipRepository = Depends(get_relationship_repository)
 ):
     """
-    Devuelve estadísticas agregadas sobre los conceptos y su proceso de síntesis.
-    Por ahora, devuelve datos simulados.
+    Devuelve estadísticas agregadas sobre los conceptos y su proceso de síntesis,
+    calculadas a partir de los datos reales en los repositorios.
     """
-    # TODO: Implementar lógica real para calcular estadísticas desde el concept_repo.
-    overall_stats = [
-        SynthesisStatisticItemSchema(name="Total Conceptos", value=150),
-        SynthesisStatisticItemSchema(name="Total Relaciones", value=300), # Asumir que se obtendría de relationship_repo
-        SynthesisStatisticItemSchema(name="Documentos Procesados", value=10),
-    ]
-    type_distribution = {
-        "DOCUMENT_SOURCE": 10,
-        "UCM": 80,
-        "CLUSTER": 25,
-        "PROPOSITION": 20,
-        "MINI_THEORY": 10,
-        "COMPREHENSIVE_THEORY": 3,
-        "UNIFIED_MODEL": 2,
-    }
-    return SynthesisStatisticsResponseSchema(
-        overall_stats=overall_stats,
-        type_distribution=type_distribution
-    )
+    try:
+        all_concepts = await concept_repo.list_all()
+        all_relationships = await relationship_repo.list_all()
+
+        num_total_concepts = len(all_concepts)
+        num_total_relationships = len(all_relationships)
+
+        num_documents_processed = 0
+        type_distribution: Dict[str, int] = defaultdict(int)
+
+        for concept in all_concepts:
+            concept_type_str = concept.concept_type.value
+            type_distribution[concept_type_str] += 1
+            if concept.concept_type == ConceptType.DOCUMENT_SOURCE:
+                num_documents_processed += 1
+
+        overall_stats = [
+            SynthesisStatisticItemSchema(name="Total Conceptos Registrados", value=num_total_concepts),
+            SynthesisStatisticItemSchema(name="Total Relaciones Registradas", value=num_total_relationships),
+            SynthesisStatisticItemSchema(name="Documentos Fuente Procesados", value=num_documents_processed),
+        ]
+
+        return SynthesisStatisticsResponseSchema(
+            overall_stats=overall_stats,
+            type_distribution=dict(type_distribution)
+        )
+    except Exception as e:
+        # Log e
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Error interno calculando estadísticas: {str(e)}")
 
 ```

--- a/Aletheia_v3/tests/test_api.py
+++ b/Aletheia_v3/tests/test_api.py
@@ -1011,22 +1011,97 @@ async def test_eje_y_functional_endpoints_unauthorized(
 
 @pytest.mark.asyncio
 async def test_get_hierarchy_graph_success(test_client: AsyncClient, researcher_token: str):
-    """Prueba el endpoint del grafo de jerarquía con un ID simulado."""
+    """Prueba el endpoint del grafo de jerarquía con datos reales y diferentes profundidades."""
     headers = {"Authorization": f"Bearer {researcher_token}"}
-    # Usar un ID que el endpoint simulado espera
-    concept_id_simulado = "unifiedm_placeholder_0"
-    response = await test_client.get(f"/eje-y/visualization/hierarchy_graph/{concept_id_simulado}", headers=headers)
+    db = next(override_get_db_session())
+    try:
+        db.query(DirectedRelationshipDB).delete()
+        db.query(ScientificConceptDB).delete()
+        db.commit()
 
-    assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert "nodes" in data
-    assert "edges" in data
-    assert isinstance(data["nodes"], list)
-    assert isinstance(data["edges"], list)
-    if data["nodes"]:
-        assert "id" in data["nodes"][0]
-        assert "label" in data["nodes"][0]
-        assert "type" in data["nodes"][0]
+        # Crear jerarquía: UM1 -> CT1 -> MT1 -> P1 -> CL1 -> (UCM1, UCM2)
+        ucm1 = await create_concept_in_db(db, "UCM1", DomainConceptType.UCM, "Data point A")
+        ucm2 = await create_concept_in_db(db, "UCM2", DomainConceptType.UCM, "Data point B")
+        cl1 = await create_concept_in_db(db, "Cluster1", DomainConceptType.CLUSTER, properties={"member_concept_ids": [str(ucm1.id), str(ucm2.id)], "shared_keywords": ["test"]})
+        p1 = await create_concept_in_db(db, "Proposition1", DomainConceptType.PROPOSITION, properties={"based_on_cluster_id": str(cl1.id), "involved_ucm_ids": [str(ucm1.id), str(ucm2.id)]})
+        mt1 = await create_concept_in_db(db, "MiniTheory1", DomainConceptType.MINI_THEORY, properties={"member_proposition_ids": [str(p1.id)]})
+        ct1 = await create_concept_in_db(db, "CompTheory1", DomainConceptType.COMPREHENSIVE_THEORY, properties={"member_mini_theory_ids": [str(mt1.id)]})
+        um1 = await create_concept_in_db(db, "UnifiedModel1", DomainConceptType.UNIFIED_MODEL, properties={"member_comprehensive_theory_ids": [str(ct1.id)]})
+
+        # Test con max_depth = 0 (solo el nodo raíz)
+        response_depth0 = await test_client.get(f"/eje-y/visualization/hierarchy_graph/{um1.id}?max_depth=0", headers=headers)
+        assert response_depth0.status_code == status.HTTP_200_OK
+        data0 = response_depth0.json()
+        assert len(data0["nodes"]) == 1
+        assert data0["nodes"][0]["id"] == str(um1.id)
+        assert len(data0["edges"]) == 0
+
+        # Test con max_depth = 1 (raíz y sus hijos directos)
+        response_depth1 = await test_client.get(f"/eje-y/visualization/hierarchy_graph/{um1.id}?max_depth=1", headers=headers)
+        assert response_depth1.status_code == status.HTTP_200_OK
+        data1 = response_depth1.json()
+        # Nodos: UM1, CT1
+        assert len(data1["nodes"]) == 2
+        node_ids1 = {n["id"] for n in data1["nodes"]}
+        assert {str(um1.id), str(ct1.id)} == node_ids1
+        # Aristas: UM1 -> CT1
+        assert len(data1["edges"]) == 1
+        assert data1["edges"][0]["from"] == str(um1.id) and data1["edges"][0]["to"] == str(ct1.id)
+
+        # Test con max_depth = 2 (UM1 -> CT1 -> MT1)
+        response_depth2 = await test_client.get(f"/eje-y/visualization/hierarchy_graph/{um1.id}?max_depth=2", headers=headers)
+        assert response_depth2.status_code == status.HTTP_200_OK
+        data2 = response_depth2.json()
+        # Nodos: UM1, CT1, MT1
+        assert len(data2["nodes"]) == 3
+        node_ids2 = {n["id"] for n in data2["nodes"]}
+        assert {str(um1.id), str(ct1.id), str(mt1.id)} == node_ids2
+        # Aristas: UM1->CT1, CT1->MT1
+        assert len(data2["edges"]) == 2
+        edge_pairs2 = {(e["from"], e["to"]) for e in data2["edges"]}
+        assert {(str(um1.id), str(ct1.id)), (str(ct1.id), str(mt1.id))} == edge_pairs2
+
+        # Test con max_depth = 5 (toda la jerarquía)
+        response_depth5 = await test_client.get(f"/eje-y/visualization/hierarchy_graph/{um1.id}?max_depth=5", headers=headers)
+        assert response_depth5.status_code == status.HTTP_200_OK
+        data5 = response_depth5.json()
+        # Nodos: UM1, CT1, MT1, P1, CL1, UCM1, UCM2 (total 7)
+        # La lógica actual de BFS podría añadir UCM1 y UCM2 dos veces si P1 y CL1 los referencian y ambos están dentro de max_depth.
+        # El uso de `nodes_map` en el endpoint debería manejar la unicidad de nodos.
+        # El `involved_ucm_ids` en la Proposición P1 también crea aristas a UCM1 y UCM2.
+        # El `member_concept_ids` en Cluster CL1 también crea aristas a UCM1 y UCM2.
+        # La clave `ids_in_bfs_queue_or_processed` previene que un mismo nodo se expanda múltiples veces.
+        # Los nodos UCM solo se añaden a la cola una vez.
+
+        # Esperados: UM1, CT1, MT1, P1, CL1, UCM1, UCM2
+        # La propiedad de P1 es "involved_ucm_ids": [ucm1, ucm2]
+        # La propiedad de CL1 es "member_concept_ids": [ucm1, ucm2]
+        # Si P1 es hijo de MT1 (nivel 3), y CL1 es referenciado por P1 (podría ser nivel 4 si se modela así)
+        # y UCMs son hijos de CL1 (nivel 5) y también de P1 (nivel 4).
+        # El BFS actual con `ids_in_bfs_queue_or_processed` asegura que cada nodo se procese una vez.
+        # El `level` en el nodo será el del primer camino encontrado.
+
+        # Nodos esperados: UM1, CT1, MT1, P1.
+        # Si P1.properties["involved_ucm_ids"] se expande: UCM1, UCM2. Total 6 nodos.
+        # Si P1.properties["based_on_cluster_id"] se expande y luego CL1.properties["member_concept_ids"]: CL1, UCM1, UCM2. Total 7 nodos.
+        # La lógica del endpoint actual prioriza `member_ids_property_key` según el tipo.
+        # Para PROPOSITION, es `involved_ucm_ids`.
+        # Nodos: UM1(0), CT1(1), MT1(2), P1(3), UCM1(4), UCM2(4). Total 6.
+        # Aristas: UM1->CT1, CT1->MT1, MT1->P1, P1->UCM1, P1->UCM2. Total 5.
+
+        assert len(data5["nodes"]) == 6
+        node_ids5 = {n["id"] for n in data5["nodes"]}
+        assert {str(um1.id), str(ct1.id), str(mt1.id), str(p1.id), str(ucm1.id), str(ucm2.id)} == node_ids5
+        assert len(data5["edges"]) == 5
+        edge_pairs5 = {(e["from"], e["to"]) for e in data5["edges"]}
+        expected_edges5 = {
+            (str(um1.id), str(ct1.id)), (str(ct1.id), str(mt1.id)), (str(mt1.id), str(p1.id)),
+            (str(p1.id), str(ucm1.id)), (str(p1.id), str(ucm2.id))
+        }
+        assert edge_pairs5 == expected_edges5
+
+    finally:
+        db.close()
 
 @pytest.mark.asyncio
 async def test_get_hierarchy_graph_not_found(test_client: AsyncClient, researcher_token: str):
@@ -1038,22 +1113,51 @@ async def test_get_hierarchy_graph_not_found(test_client: AsyncClient, researche
 
 @pytest.mark.asyncio
 async def test_get_synthesis_statistics_success(test_client: AsyncClient, researcher_token: str):
-    """Prueba el endpoint de estadísticas de síntesis."""
+    """Prueba el endpoint de estadísticas de síntesis con datos reales."""
     headers = {"Authorization": f"Bearer {researcher_token}"}
-    response = await test_client.get("/eje-y/visualization/synthesis_statistics", headers=headers)
+    db = next(override_get_db_session())
+    try:
+        # Limpiar y preparar datos
+        db.query(DirectedRelationshipDB).delete()
+        db.query(ScientificConceptDB).delete()
+        db.commit()
 
-    assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert "overall_stats" in data
-    assert "type_distribution" in data
-    assert isinstance(data["overall_stats"], list)
-    assert isinstance(data["type_distribution"], dict)
-    if data["overall_stats"]:
-        assert "name" in data["overall_stats"][0]
-        assert "value" in data["overall_stats"][0]
-    if data["type_distribution"]:
-        # Verificar que alguna clave esperada exista, ej. "UCM"
-        assert "UCM" in data["type_distribution"] or not data["type_distribution"] # Puede ser vacío si no hay datos
+        # Crear algunos conceptos de diferentes tipos
+        doc1 = await create_concept_in_db(db, "Doc 1", DomainConceptType.DOCUMENT_SOURCE)
+        ucm1 = await create_concept_in_db(db, "UCM 1", DomainConceptType.UCM)
+        ucm2 = await create_concept_in_db(db, "UCM 2", DomainConceptType.UCM)
+        cluster1 = await create_concept_in_db(db, "Cluster 1", DomainConceptType.CLUSTER)
+        # Crear algunas relaciones (necesitaríamos un helper o crearlas manualmente si el endpoint las cuenta)
+        # Por ahora, el endpoint solo cuenta conceptos y documentos fuente.
+        # Si se añade el conteo de relaciones al endpoint, este test necesitaría crear relaciones también.
+        # La implementación actual de get_synthesis_statistics sí cuenta relaciones.
+        from Aletheia_v3.infrastructure.models import DirectedRelationshipDB as RelDBModel
+        rel1 = RelDBModel(source_concept_id=doc1.id, target_concept_id=ucm1.id, type="EXTRACTED_FROM")
+        rel2 = RelDBModel(source_concept_id=ucm1.id, target_concept_id=ucm2.id, type="RELATES_TO")
+        db.add_all([rel1, rel2])
+        db.commit()
+
+        response = await test_client.get("/eje-y/visualization/synthesis_statistics", headers=headers)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        assert "overall_stats" in data
+        assert "type_distribution" in data
+
+        stats_map = {item["name"]: item["value"] for item in data["overall_stats"]}
+        assert stats_map["Total Conceptos Registrados"] == 4 # doc1, ucm1, ucm2, cluster1
+        assert stats_map["Total Relaciones Registradas"] == 2
+        assert stats_map["Documentos Fuente Procesados"] == 1
+
+        type_dist = data["type_distribution"]
+        assert type_dist[DomainConceptType.DOCUMENT_SOURCE.value] == 1
+        assert type_dist[DomainConceptType.UCM.value] == 2
+        assert type_dist[DomainConceptType.CLUSTER.value] == 1
+        assert DomainConceptType.PROPOSITION.value not in type_dist # No se crearon proposiciones
+
+    finally:
+        db.close()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("path", [


### PR DESCRIPTION
Replaces simulated data with real data fetching and processing for knowledge graph visualization API endpoints.

Key changes:
- `GET /eje-x/concepts/` and `GET /eje-x/relationships/`:
  - Implemented in `ontology_management_router.py`.
  - Fetch all concepts/relationships from `IConceptRepository` and `IRelationshipRepository` respectively.
  - Return `List[ScientificConceptSchema]` and `List[RelationshipSchema]`.
  - Added `list_all()` methods to repository interfaces and their SQLAlchemy & InMemory implementations.
- `GET /eje-y/visualization/hierarchy_graph/{concept_id}`:
  - Implemented in `knowledge_synthesis_router.py`.
  - Fetches concept hierarchy from `IConceptRepository` using BFS up to a specified `max_depth`.
  - Determines child concepts based on `member_*_ids` properties in parent concepts.
  - Returns `HierarchyGraphResponseSchema` with actual nodes and edges.
- `GET /eje-y/visualization/synthesis_statistics`:
  - Implemented in `knowledge_synthesis_router.py`.
  - Calculates statistics (total concepts, total relationships, documents processed, type distribution) by querying `IConceptRepository` and `IRelationshipRepository`.
  - Returns `SynthesisStatisticsResponseSchema` with real data.
- API Schemas (`api/schemas.py`):
  - Added `ScientificConceptSchema` for detailed concept representation.
  - Defined `HierarchyGraphNodeSchema`, `HierarchyGraphEdgeSchema`, `HierarchyGraphResponseSchema`, `SynthesisStatisticItemSchema`, and `SynthesisStatisticsResponseSchema` for visualization endpoints.
- API Tests (`tests/test_api.py`):
  - Updated tests for visualization endpoints to set up data in the test DB and verify that API responses correctly reflect this data.
  - `test_get_hierarchy_graph_success` now tests different `max_depth` values against a predefined hierarchy.
  - `test_get_synthesis_statistics_success` verifies calculated stats against a known dataset in the test DB.
- Documentation: Updated docstrings for modified router endpoints.

The dashboard will now receive and display real-time data from the application's knowledge graph.