### PR TITLE
feat: Implement functional AdaptiveAnalysisEngine logic

### DIFF
--- a/Aletheia_v3/application/use_cases.py
+++ b/Aletheia_v3/application/use_cases.py
@@ -423,9 +423,50 @@ class AdaptiveAnalysisEngine:
             num_strategies = len(self.strategy_weights)
             if num_strategies > 0: self.strategy_weights = {k: 1.0/num_strategies for k in self.strategy_weights}
 
-    def _calculate_performance_gradients(self, metrics: dict) -> Dict[str, float]:
-        # print("AdaptiveAnalysisEngine: Calculating performance gradients (placeholder).")
-        return {s: metrics.get(f"{s}_score_improvement", random.uniform(-0.1, 0.1)) for s in self.strategy_weights}
+    def _calculate_success_metric(self, metrics: dict) -> float:
+        """
+        Calcula una métrica de éxito compuesta basada en las métricas de rendimiento.
+        """
+        confidence = metrics.get('consensus_confidence', 0.0) or 0.0 # Asegurar que no sea None
+
+        num_insights = 0
+        final_model = metrics.get('final_model')
+        if isinstance(final_model, dict):
+            # La estructura esperada es que final_model contenga combined_unique_insights_app
+            # como se define en CubeHoneycombIntegration._integrate_perspectives
+            insights = final_model.get('combined_unique_insights_app', [])
+            if isinstance(insights, list):
+                num_insights = len(insights)
+
+        # Métrica de éxito: ponderar confianza y número de insights (normalizado)
+        # Normalizar num_insights a un rango [0,1] (ej. capado a 10 insights max para la contribución)
+        normalized_insights_score = min(num_insights, 10) / 10.0
+
+        success_score = (confidence * 0.7) + (normalized_insights_score * 0.3)
+        return success_score
+
+    def _calculate_performance_gradients(self, performance_metrics: dict) -> Dict[str, float]:
+        """
+        Calcula los gradientes de rendimiento para cada estrategia.
+        El gradiente es positivo si la estrategia usada tuvo éxito, negativo si no.
+        Las estrategias no usadas tienen gradiente cero.
+        """
+        success_score = self._calculate_success_metric(performance_metrics)
+
+        gradients: Dict[str, float] = {}
+        strategy_used = performance_metrics.get('strategy_used', 'exhaustive') # Default a una estrategia conocida
+
+        for strategy_name in self.strategy_weights.keys():
+            if strategy_name == strategy_used:
+                # El gradiente es la "sorpresa": éxito actual vs. un umbral (0.5).
+                # Un valor > 0 significa mejor que el umbral, < 0 peor.
+                gradient = success_score - 0.5
+                gradients[strategy_name] = gradient
+            else:
+                # No actualizamos las estrategias que no se usaron en esta ronda.
+                gradients[strategy_name] = 0.0
+
+        return gradients
 
     def select_optimal_path(self, analysis_context: dict) -> List[str]:
         context_features = self._extract_context_features(analysis_context)
@@ -439,9 +480,49 @@ class AdaptiveAnalysisEngine:
         return {"data_size": context.get("data_size", 100), "complexity_est": context.get("complexity_estimate", 0.5)}
 
     def _evaluate_strategy_fit(self, strategy: str, features: Dict[str, Any]) -> float:
-        # print(f"AdaptiveAnalysisEngine: Evaluating fit for strategy {strategy} (placeholder).")
-        if strategy == 'exhaustive': return 1.0 / (1 + features.get("data_size", 1000) * 0.01 + 1e-6) # Avoid div by zero
-        return random.random()
+        """
+        Evalúa qué tan adecuada es una estrategia dado un contexto de análisis.
+        Devuelve un score entre (aprox) 0.1 y 1.0.
+        """
+        data_size = features.get('data_size', 1000) # Default si no está
+        complexity = features.get('complexity_est', 0.5) # Default si no está
+
+        score = 0.1 # Default score bajo
+
+        if strategy == 'exhaustive':
+            # Favorece datos pequeños y de baja complejidad. Penalizado por tamaño y complejidad.
+            # El score disminuye a medida que data_size o complexity aumentan.
+            # (data_size / 5000.0) -> 0.2 para data_size=1000; 1.0 para data_size=5000; 2.0 para data_size=10000
+            # complexity es 0.0 a 1.0
+            denominator = 1.0 + (data_size / 5000.0) + (complexity * 2.0) # Ponderar más la complejidad
+            score = 1.0 / denominator if denominator > 0.1 else 0.1 # Evitar división por cero o score muy alto
+
+        elif strategy == 'progressive':
+            # Bueno para datos de tamaño medio, menos sensible a la complejidad inicial.
+            # Score base alto, penalizado ligeramente por extremos de tamaño.
+            base_score = 0.8
+            if data_size > 15000 or data_size < 500:
+                base_score -= 0.2 # Penalización mayor
+            elif data_size > 8000 or data_size < 1000:
+                base_score -= 0.1
+            # Ligera penalización por muy baja complejidad (podría no necesitar 'progressive')
+            if complexity < 0.2:
+                 base_score -= 0.1
+            score = base_score
+
+        elif strategy == 'temporal' or strategy == 'causal':
+            # Favorecido si la complejidad estimada es alta (sugiere que hay estructura para encontrar).
+            # Score base + bonus por complejidad.
+            score = 0.3 + complexity * 0.7 # Rango ~0.3 a 1.0
+
+        elif strategy == 'emergent':
+             # Favorecido por datos grandes y de alta complejidad.
+             # Normalizar data_size, ej. capado a 20000 para el score.
+             norm_data_size = min(data_size, 20000) / 20000.0 # Rango 0 a 1
+             # Score base bajo, aumenta con tamaño y complejidad
+             score = 0.1 + (norm_data_size * 0.45) + (complexity * 0.45) # Rango ~0.1 a 1.0
+
+        return max(0.05, min(score, 1.0)) # Asegurar que el score esté entre 0.05 y 1.0
 
 
 # --- CubeHoneycombIntegration Class and its methods ---

--- a/Aletheia_v3/tests/integration/test_mdu_system_suite.py
+++ b/Aletheia_v3/tests/integration/test_mdu_system_suite.py
@@ -239,3 +239,97 @@ class TestMDUSystemSuite:
                     # This is a very loose conceptual check.
                     # assert time_ratio < (size_ratio ** 1.8), f"Potential scaling performance issue at size {curr_res['size']}"
                     pass # Actual scaling assertions depend on expected complexity and real timings.
+
+    @pytest.mark.asyncio
+    async def test_adaptive_engine_learns_from_runs(self, mocker): # mdu_system_integration_instance no es necesaria aquí
+        """
+        Tests if the AdaptiveAnalysisEngine adapts its strategy_weights based on simulated performance.
+        """
+        from ...application.use_cases import AdaptiveAnalysisEngine # Importar la clase
+
+        adaptive_engine = AdaptiveAnalysisEngine()
+        initial_weights = adaptive_engine.strategy_weights.copy()
+        num_runs = 20 # Aumentar para ver un efecto más claro
+        target_strategy_to_reward = 'emergent'
+
+        # Para observar la evolución (opcional)
+        # weight_history = {strategy: [weight] for strategy, weight in initial_weights.items()}
+
+        for i in range(num_runs):
+            # 1. Crear contexto de análisis simulado
+            # Podríamos variar esto, o mantenerlo constante para ver si converge a la mejor estrategia para ESE contexto.
+            # Por ahora, un contexto que podría favorecer 'emergent' (datos grandes, alta complejidad)
+            analysis_context_sim = {
+                'data_size': random.randint(8000, 15000),
+                'complexity_estimate': random.uniform(0.6, 0.9)
+            }
+
+            # 2. El motor selecciona una estrategia
+            # select_optimal_path devuelve una lista ordenada, tomamos la primera
+            optimal_paths = adaptive_engine.select_optimal_path(analysis_context_sim)
+            if not optimal_paths:
+                # Esto no debería pasar si _evaluate_strategy_fit siempre devuelve > 0 y hay estrategias
+                chosen_strategy = list(adaptive_engine.strategy_weights.keys())[0] # Fallback
+            else:
+                chosen_strategy = optimal_paths[0]
+
+            # 3. Simular métricas de rendimiento basadas en la estrategia elegida
+            simulated_performance_metrics = {
+                'strategy_used': chosen_strategy,
+                'consensus_confidence': 0.0,
+                'final_model': {'combined_unique_insights_app': []},
+                # Añadir otras métricas que _calculate_success_metric podría usar
+            }
+
+            if chosen_strategy == target_strategy_to_reward:
+                # Simular un buen resultado
+                simulated_performance_metrics['consensus_confidence'] = random.uniform(0.7, 0.95)
+                simulated_performance_metrics['final_model']['combined_unique_insights_app'] = [f"insight_{k}" for k in range(random.randint(5,10))]
+            else:
+                # Simular un resultado mediocre o malo
+                simulated_performance_metrics['consensus_confidence'] = random.uniform(0.2, 0.5)
+                simulated_performance_metrics['final_model']['combined_unique_insights_app'] = [f"insight_{k}" for k in range(random.randint(0,2))]
+
+            # 4. El motor adapta su estrategia
+            adaptive_engine.adapt_strategy(simulated_performance_metrics)
+
+            # for strategy, weight in adaptive_engine.strategy_weights.items():
+            #     weight_history[strategy].append(weight)
+
+        # Imprimir historial de pesos para depuración (opcional)
+        # print("\nWeight history:")
+        # for strategy, history in weight_history.items():
+        #     print(f"{strategy}: {[f'{w:.3f}' for w in history]}")
+        # print(f"Final weights: {adaptive_engine.strategy_weights}")
+
+        # 5. Aserción final
+        final_weights = adaptive_engine.strategy_weights
+
+        # Verificar que el peso de la estrategia recompensada es el más alto o ha aumentado significativamente
+        rewarded_strategy_final_weight = final_weights.get(target_strategy_to_reward, 0)
+
+        # Comprobar que es el más alto
+        is_highest = True
+        for strategy, weight in final_weights.items():
+            if strategy != target_strategy_to_reward and weight > rewarded_strategy_final_weight:
+                is_highest = False
+                break
+
+        # Comprobar que ha aumentado respecto al inicial (después de la primera normalización)
+        # La primera normalización hace que todos los pesos sean 1/num_strategies si empiezan en 1.0
+        num_strategies = len(initial_weights)
+        initial_normalized_weight_approx = 1.0 / num_strategies if num_strategies > 0 else 0
+
+        # Puede que no sea el *más* alto si otras estrategias también dieron buenos resultados por casualidad
+        # o si el contexto cambiaba mucho. Una aserción más robusta es que haya aumentado.
+        # Para este test, como forzamos el "éxito" de la target_strategy, debería ser el más alto.
+        assert rewarded_strategy_final_weight > initial_normalized_weight_approx, \
+            f"El peso de la estrategia recompensada '{target_strategy_to_reward}' ({rewarded_strategy_final_weight:.3f}) no aumentó significativamente respecto al inicial (~{initial_normalized_weight_approx:.3f}). Final weights: {final_weights}"
+
+        # Y que es considerablemente mayor que al menos alguna otra estrategia (si hay más de una)
+        if num_strategies > 1:
+            other_weights_sum = sum(w for s, w in final_weights.items() if s != target_strategy_to_reward)
+            avg_other_weight = other_weights_sum / (num_strategies -1) if (num_strategies -1) > 0 else 0
+            assert rewarded_strategy_final_weight > avg_other_weight, \
+                f"El peso de la estrategia recompensada '{target_strategy_to_reward}' ({rewarded_strategy_final_weight:.3f}) no es mayor que el promedio de las otras ({avg_other_weight:.3f}). Final weights: {final_weights}"
+            assert is_highest, f"La estrategia recompensada '{target_strategy_to_reward}' no terminó con el peso más alto. Final weights: {final_weights}"


### PR DESCRIPTION
Replaces placeholder and random logic in AdaptiveAnalysisEngine with functional implementations for performance gradient calculation and strategy fitness evaluation.

Key changes in Aletheia_v3/application/use_cases.py:
- `AdaptiveAnalysisEngine._calculate_success_metric()`: New private helper method to compute a composite success score based on 'consensus_confidence' and 'num_insights' from performance_metrics.
- `AdaptiveAnalysisEngine._calculate_performance_gradients()`:
  - Now uses `_calculate_success_metric()`.
  - Gradient for the used strategy is `success_score - 0.5`.
  - Gradient for unused strategies is `0.0`.
- `AdaptiveAnalysisEngine._evaluate_strategy_fit()`:
  - Replaced random/simple logic with heuristics based on context features ('data_size', 'complexity_est').
  - Different scoring logic for 'exhaustive', 'progressive', 'temporal'/'causal', and 'emergent' strategies.
  - Scores are normalized approximately to the [0.05, 1.0] range.

New integration test in Aletheia_v3/tests/integration/test_mdu_system_suite.py:
- `test_adaptive_engine_learns_from_runs()`:
  - Simulates multiple analysis runs.
  - Selects strategies using `select_optimal_path()`.
  - Generates simulated `performance_metrics` to selectively "reward" a target strategy.
  - Calls `adapt_strategy()` to update strategy weights.
  - Asserts that the rewarded strategy's weight increases and becomes dominant over iterations.

Documentation:
- Added/updated docstrings for modified methods in AdaptiveAnalysisEngine and for the new integration test.

This change makes the AdaptiveAnalysisEngine capable of more meaningful strategy adaptation based on defined heuristics and performance feedback.