### PR TITLE
Consolidate MDU, attempt env unblocking, and implement re-analysis

### DIFF
--- a/Aletheia_v3/Dockerfile
+++ b/Aletheia_v3/Dockerfile
@@ -17,8 +17,9 @@ WORKDIR /opt/aletheia
 # this might be minimal. netcat-openbsd is for the entrypoint script's DB check.
 # For cypari2 (PARI/GP), we need libgmp-dev, libmpfr-dev, libmpc-dev.
 # Numba often needs llvm and tbb, but pip wheels might handle this. Let's add build-essentials.
+# Added libpari-dev for cypari2 compilation
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends netcat-openbsd gcc build-essential libgmp-dev libmpfr-dev libmpc-dev postgresql-client && \
+    apt-get install -y --no-install-recommends netcat-openbsd gcc build-essential libgmp-dev libmpfr-dev libmpc-dev libpari-dev postgresql-client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Aletheia_v3/alembic/env.py
+++ b/Aletheia_v3/alembic/env.py
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 import os
+import sys
+# Añadir la raíz del proyecto (directorio padre de Aletheia_v3) al path
+# Asumiendo que env.py está en Aletheia_v3/alembic/
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from logging.config import fileConfig
 
 from alembic import context


### PR DESCRIPTION
FASE 1: DESBLOQUEO DEL ENTORNO (Intentos)
- Modified Aletheia_v3/alembic/env.py to correctly set sys.path for Alembic to find application models.
- Modified Aletheia_v3/Dockerfile to include libpari-dev, aiming to resolve cypari2 system dependency for PARI/GP.
- NOTE: Dependency installation (cypari2) and thus availability of Alembic and Pytest remained blocked in the execution environment.

FASE 2: IMPLEMENTACIÓN DE LÓGICA Y MIGRACIÓN
- Implemented re-analysis logic in CubicAnalysisPipeline._rotate_and_analyze (application/use_cases.py):
  - Fetches rotated cube components.
  - Creates a new content string from rotated components.
  - Re-runs the DomainService pipeline (extract_atomic_units, form_clusters, build_mini_theories, synthesize_model, calculate_metrics) on this new content for each perspective.
- Activated cube state reset by calling self.cube.reset_orientation() at the end of CubicAnalysisPipeline.execute_full_analysis.
- NOTE: Alembic migration generation for new/updated models was blocked due to environment issues.

FASE 3: VALIDACIÓN Y CIERRE (Conceptual)
- Test suite execution and final documentation updates were planned but could not be performed due to the unresolved environment blockages.

This commit includes the code changes for the specified logic. Full validation requires a functional build environment where system dependencies can be met, and migrations and tests can be run.