### PR TITLE
Implement and verify user disable functionality

### DIFF
--- a/Aletheia_v3/alembic.ini
+++ b/Aletheia_v3/alembic.ini
@@ -71,4 +71,3 @@ formatter = generic
 [formatter_generic]
 format = %%(levelname)-5.5s [%%(name)s] %%(message)s
 datefmt = %%H:%%M:%%S
-```

--- a/Aletheia_v3/infrastructure/models.py
+++ b/Aletheia_v3/infrastructure/models.py
@@ -21,7 +21,7 @@ from sqlalchemy import Boolean, Column, DateTime, TypeDecorator
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy import Float, ForeignKey, Integer, String, Table, Text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID  # For PostgreSQL UUID type
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, Mapped, mapped_column # Consolidated imports
 from sqlalchemy.sql import func  # For server-side default timestamps if preferred
 
 # Custom UUID type for SQLite compatibility
@@ -118,23 +118,23 @@ conjecture_hits_association = Table(
 class ResearcherDB(Base):
     __tablename__ = "researchers"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid_pkg.uuid4)
-    username = Column(String(100), unique=True, index=True, nullable=False)
-    full_name = Column(String(255), nullable=True)
-    email = Column(String(255), unique=True, index=True, nullable=False)
-    orcid = Column(
+    id: Mapped[uuid_pkg.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid_pkg.uuid4)
+    username: Mapped[str] = mapped_column(String(100), unique=True, index=True, nullable=False)
+    full_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    orcid: Mapped[Optional[str]] = mapped_column(
         String(50), unique=True, nullable=True, index=True
     )  # ORCID iDs are typically 19 chars like 0000-0002-1825-0097
-    hashed_password = Column(
+    hashed_password: Mapped[str] = mapped_column(
         String, nullable=False
     )  # Store hashed passwords only
-    is_admin = Column(Boolean, default=False, nullable=False)
-    disabled = Column(
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False) # server_default=sa.false() could be added if needed
+    disabled: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False, server_default=sa.false()
-    )  # New field for disabling accounts
+    )  # Ensures field exists with Mapped syntax
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 


### PR DESCRIPTION
- Updated ResearcherDB model in infrastructure/models.py to use SQLAlchemy 2.0 Mapped syntax.
- Confirmed that the Alembic migration 'rev_0003_add_disabled_to_researchers.py' correctly adds the 'disabled' field with appropriate defaults. No new migration was needed as this existing migration covers the schema change.
- Verified that Aletheia_v3/api/auth.py (get_researcher_for_auth) correctly maps the ResearcherDB.disabled status to UserInDB.disabled.
- Verified that aletheia_common/auth/jwt_handler.py (get_current_active_user) correctly checks the UserInDB.disabled field and denies access to disabled users.

This completes the requirements for adding and handling the 'disabled' field for researchers, enhancing user security.