### PR TITLE
Refactor: Centralize auth components and DB models to aletheia_common

### DIFF
--- a/aletheia_common/auth/models.py
+++ b/aletheia_common/auth/models.py
@@ -1,0 +1,48 @@
+# aletheia_common/auth/models.py
+import uuid as uuid_pkg
+from datetime import datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, DateTime, String, ForeignKey # ForeignKey might not be needed if relationships are removed
+from sqlalchemy.orm import Mapped, mapped_column, relationship # relationship might not be needed
+
+from ..db.base import Base # Import shared Base
+from ..db.custom_types import UUID # Import custom UUID type
+from sqlalchemy.sql import func
+
+class ResearcherDB(Base):
+    __tablename__ = "researchers"
+
+    id: Mapped[uuid_pkg.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid_pkg.uuid4)
+    username: Mapped[str] = mapped_column(String(100), unique=True, index=True, nullable=False)
+    full_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    orcid: Mapped[Optional[str]] = mapped_column(
+        String(50), unique=True, nullable=True, index=True
+    )
+    hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    disabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default=sa.false()
+    )
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships to Aletheia_v3 models are removed from here.
+    # They will be defined in Aletheia_v3 models pointing to this common ResearcherDB.
+    # e.g., in Aletheia_v3.infrastructure.models.JobDB:
+    # submitter = relationship("aletheia_common.auth.models.ResearcherDB", back_populates="submitted_jobs_placeholder")
+    # And ResearcherDB would need a placeholder if back_populates is used, or relationships are one-way from Aletheia_v3.
+    # For now, keeping it simple by removing them from the common model.
+    # If back_populates are needed, they'd be like:
+    # submitted_jobs = relationship("Aletheia_v3.infrastructure.models.JobDB", back_populates="submitter") # This is an anti-pattern for common lib
+    # A better way is for JobDB in Aletheia_v3 to define the full relationship.
+
+    def __repr__(self):
+        return (
+            f"<ResearcherDB(username='{self.username}', email='{self.email}')>"
+        )

--- a/aletheia_common/auth/schemas.py
+++ b/aletheia_common/auth/schemas.py
@@ -1,0 +1,104 @@
+# aletheia_common/auth/schemas.py
+import uuid as uuid_pkg
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field # Add EmailStr if/when email validation is desired
+
+# --- Token Schemas ---
+class Token(BaseModel):
+    """Schema for the JWT access token."""
+    access_token: str
+    token_type: str = "bearer"
+
+class TokenData(BaseModel):
+    """
+    Pydantic model representing the data encoded within a JWT token.
+    Typically includes username and scopes (roles/permissions).
+    """
+    username: Optional[str] = None
+    scopes: List[str] = [] # Kept from jwt_handler.py version, Aletheia_v3.api.schemas had only username
+
+# --- User Schemas ---
+# These are primarily for API interaction (request/response).
+
+class UserBase(BaseModel): # From Aletheia_v3/api/schemas.py
+    username: str = Field(..., min_length=3, max_length=50)
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+
+class UserCreate(UserBase): # From Aletheia_v3/api/schemas.py
+    password: str = Field(
+        ..., min_length=8, description="User's password (will be hashed)."
+    )
+
+class UserResponse(UserBase): # From Aletheia_v3/api/schemas.py
+    """Schema for returning user information (without password)."""
+    # Note: The 'disabled' field was in Aletheia_v3's UserResponse.
+    # It's also in UserInDB. For a public UserResponse, it might be relevant.
+    # Keeping it consistent with UserInDB for now.
+    disabled: bool = False
+
+    class Config:
+        orm_mode = True
+
+# --- Researcher Schemas (specific to Aletheia_v3's concept of Researcher) ---
+# These are kept separate from generic User schemas if Researcher has more specific fields
+
+class ResearcherBase(BaseModel): # From Aletheia_v3/api/schemas.py
+    username: str = Field(..., min_length=3, max_length=100)
+    full_name: Optional[str] = Field(None, max_length=255)
+    email: str = Field(..., max_length=255)
+    orcid: Optional[str] = Field(
+        None, max_length=50, description="ORCID iD, e.g., 0000-0000-0000-0000"
+    )
+
+class ResearcherCreate(ResearcherBase): # From Aletheia_v3/api/schemas.py
+    password: str = Field(
+        ...,
+        min_length=8,
+        description="Researcher's password (will be hashed upon creation)",
+    )
+
+class ResearcherUpdate(BaseModel): # From Aletheia_v3/api/schemas.py
+    full_name: Optional[str] = Field(None, max_length=255)
+    email: Optional[str] = Field(None, max_length=255)
+    orcid: Optional[str] = Field(None, max_length=50)
+
+class ResearcherResponse(ResearcherBase): # From Aletheia_v3/api/schemas.py
+    id: uuid_pkg.UUID
+    created_at: datetime
+    updated_at: datetime
+    disabled: bool = False # Added to be consistent with UserInDB and common UserResponse
+
+    class Config:
+        orm_mode = True
+
+# --- Internal Authentication User Models ---
+# These were originally in aletheia_common.auth.jwt_handler
+
+class UserInDB(BaseModel):
+    """
+    Pydantic model representing a user object as stored in or retrieved from the database.
+    Includes sensitive information like hashed_password and status fields like 'disabled'.
+    This is used internally by the authentication logic.
+    """
+    username: str
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+    hashed_password: Optional[str] = None # Should be str if present, Optional if user might not have a password (e.g. external OAuth)
+    roles: List[str] = Field(default_factory=list)
+    disabled: bool = False
+
+class UserAuth(BaseModel):
+    """
+    Pydantic model representing an authenticated user's identity.
+    This model is typically what `get_current_active_user` returns and contains
+    non-sensitive information safe to use in the application context after authentication.
+    """
+    username: str
+    roles: List[str] = Field(default_factory=list)
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+    # No 'disabled' field here, as get_current_active_user should not return disabled users.
+    # No 'hashed_password'.

--- a/aletheia_common/db/base.py
+++ b/aletheia_common/db/base.py
@@ -1,0 +1,4 @@
+# aletheia_common/db/base.py
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/aletheia_common/db/custom_types.py
+++ b/aletheia_common/db/custom_types.py
@@ -1,0 +1,46 @@
+# aletheia_common/db/custom_types.py
+import uuid as uuid_pkg
+from sqlalchemy import TypeDecorator, String
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+class UUID(TypeDecorator):
+    """Platform-independent UUID type.
+
+    Uses PostgreSQL's UUID type, otherwise uses
+    CHAR(32), storing as string.
+    """
+    impl = String(32) # Default implementation for non-PG dialects
+    cache_ok = True
+
+    def __init__(self, as_uuid=True, *args, **kwargs):
+        self.as_uuid = as_uuid
+        super(UUID, self).__init__()
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'postgresql':
+            return dialect.type_descriptor(PG_UUID(as_uuid=self.as_uuid))
+        else:
+            return dialect.type_descriptor(String(32))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        if dialect.name != 'postgresql':
+            if isinstance(value, uuid_pkg.UUID):
+                return str(value)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        if dialect.name == 'postgresql':
+            if self.as_uuid and isinstance(value, str): return uuid_pkg.UUID(value)
+            return value
+        else:
+            if self.as_uuid:
+                if isinstance(value, uuid_pkg.UUID): return value
+                try:
+                    return uuid_pkg.UUID(value)
+                except (TypeError, ValueError):
+                    return value
+            return value


### PR DESCRIPTION
- Created aletheia_common.db.base for shared SQLAlchemy Base.
- Created aletheia_common.db.custom_types for shared custom DB types (e.g., UUID).
- Moved ResearcherDB model to aletheia_common.auth.models.
- Centralized user/auth Pydantic schemas (Token, UserInDB, UserAuth, Researcher schemas, etc.) into aletheia_common.auth.schemas.

- Updated Aletheia_v3:
    - infrastructure/models.py: Models now use common Base and UUID type. ResearcherDB removed. Relationships updated to point to common ResearcherDB.
    - api/auth.py: Imports ResearcherDB and auth schemas from aletheia_common.
    - api/routers/: Import Pydantic schemas from aletheia_common.
    - api/schemas.py: Removed moved schema definitions.

- Updated aletheia_stats:
    - presentation/api.py: Removed mock auth; uses common jwt_handler and UserAuth schema.

- Updated aletheia_common/auth/jwt_handler.py to import its Pydantic models from aletheia_common.auth.schemas.

This refactoring promotes code reuse, consistency, and better architectural separation for authentication and core database models across different Aletheia services.