### PR TITLE
Implement core MDL synthesis engine (Phase 1) in Aletheia_v3

### DIFF
--- a/Aletheia_v3/application/mdl_synthesis_use_cases.py
+++ b/Aletheia_v3/application/mdl_synthesis_use_cases.py
@@ -1,0 +1,120 @@
+# Aletheia_v3/application/mdl_synthesis_use_cases.py
+import logging
+from typing import Any, List, Dict, Optional
+
+# Import MDL entities and services from Aletheia_v3.core.mdl_synthesis
+from ..core.mdl_synthesis.entities import (
+    ModelRepresentation,
+    ModelMetrics,
+    OptimizationResult
+)
+from ..core.mdl_synthesis.services import (
+    KolmogorovComplexityProxyService,
+    LikelihoodService, # This will be the new placeholder/Aletheia_v3 specific one
+    OmegaCostService
+)
+
+logger = logging.getLogger(__name__)
+
+class FindOptimalModelUseCase:
+    """
+    Caso de uso para encontrar el modelo óptimo (M*) de un conjunto de modelos candidatos,
+    minimizando el coste MDL (Axioma 1).
+    Adaptado de aletheia_omega.
+    """
+
+    def __init__(
+        self,
+        complexity_service: KolmogorovComplexityProxyService,
+        likelihood_service: LikelihoodService, # Expects Aletheia_v3's LikelihoodService
+        omega_cost_service: OmegaCostService,
+    ):
+        self.complexity_service = complexity_service
+        self.likelihood_service = likelihood_service
+        self.omega_cost_service = omega_cost_service
+        # logger.info("FindOptimalModelUseCase (Aletheia_v3) inicializado.")
+
+
+    def execute(
+        self,
+        candidate_models: List[ModelRepresentation],
+        data: Any, # Data 'D' against which models 'M' are evaluated
+        lambda_param: float,
+        optimization_parameters: Optional[Dict[str, Any]] = None
+    ) -> OptimizationResult:
+        """
+        Ejecuta el caso de uso para encontrar el modelo óptimo.
+
+        @param candidate_models: Lista de ModelRepresentation de modelos candidatos.
+        @param data: Los datos (D) sobre los cuales evaluar los modelos.
+                     La estructura de 'data' dependerá del contexto del Eje Y
+                     (e.g., lista de UCMs para clustering, lista de Proposiciones para teoría).
+        @param lambda_param: Parámetro de regularización λ para la función de coste MDL.
+        @param optimization_parameters: Parámetros adicionales de la optimización (opcional).
+        @return: Un objeto OptimizationResult con el mejor modelo y sus métricas.
+        @raises ValueError: Si no se proporcionan modelos candidatos o lambda_param es negativo.
+        """
+        if not candidate_models:
+            logger.error("FindOptimalModelUseCase: Se intentó ejecutar con una lista de modelos vacía.")
+            raise ValueError("La lista de modelos candidatos no puede estar vacía.")
+        if lambda_param < 0:
+            logger.error(f"FindOptimalModelUseCase: Se intentó ejecutar con lambda negativo: {lambda_param}")
+            raise ValueError("El parámetro de regularización λ no puede ser negativo.")
+
+        logger.info(
+            f"FindOptimalModelUseCase: Iniciando búsqueda del modelo óptimo en un espacio de "
+            f"{len(candidate_models)} modelos con lambda={lambda_param}."
+        )
+
+        best_model: Optional[ModelRepresentation] = None
+        best_metrics: Optional[ModelMetrics] = None
+        min_mdl_cost = float('inf')
+
+        for model_repr in candidate_models:
+            complexity = self.complexity_service.compute(model_repr.content)
+
+            # Crucially, this now calls Aletheia_v3's (placeholder) LikelihoodService
+            log_likelihood = self.likelihood_service.compute(model_repr, data) # Pass model_repr as per directive
+
+            mdl_cost = self.omega_cost_service.calculate_mdl_cost(
+                complexity=complexity,
+                log_likelihood=log_likelihood,
+                lambda_param=lambda_param,
+            )
+            logger.debug(
+                f"Modelo '{model_repr.identifier}': K={complexity:.2f}, L={log_likelihood:.4f}, MDL={mdl_cost:.4f}"
+            )
+            if mdl_cost < min_mdl_cost:
+                min_mdl_cost = mdl_cost
+                best_model = model_repr
+                best_metrics = ModelMetrics(
+                    complexity=complexity,
+                    log_likelihood=log_likelihood,
+                    mdl_cost=mdl_cost,
+                )
+
+        if best_model is None or best_metrics is None:
+            logger.error(
+                "FindOptimalModelUseCase: La búsqueda finalizó sin encontrar un modelo óptimo. "
+                "Esto puede ocurrir si todos los modelos evaluados resultaron en costos inválidos "
+                "o si el espacio de candidatos estaba vacío (aunque ya se verificó)."
+            )
+            # Consider the case where all log_likelihoods are extremely low (e.g. -1e9 from placeholder)
+            # This could lead to all mdl_costs being very high.
+            # If candidate_models was not empty, this implies an issue with metric calculation.
+            # For now, raising RuntimeError is fine.
+            raise RuntimeError("No se pudo determinar un modelo óptimo. Verifique los modelos y datos de entrada, o la implementación de LikelihoodService.")
+
+        logger.info(
+            f"FindOptimalModelUseCase: Búsqueda finalizada. Mejor modelo: '{best_model.identifier}' (Coste MDL: {min_mdl_cost:.4f})."
+        )
+
+        final_params = optimization_parameters or {}
+        final_params["lambda"] = lambda_param # Ensure lambda is recorded
+
+        return OptimizationResult(
+            best_model=best_model,
+            best_model_metrics=best_metrics,
+            search_space_size=len(candidate_models),
+            parameters=final_params
+        )

--- a/Aletheia_v3/core/mdl_synthesis/__init__.py
+++ b/Aletheia_v3/core/mdl_synthesis/__init__.py
@@ -1,0 +1,2 @@
+# This __init__.py file can remain empty.
+# It makes 'mdl_synthesis' a Python package.

--- a/Aletheia_v3/core/mdl_synthesis/adapters.py
+++ b/Aletheia_v3/core/mdl_synthesis/adapters.py
@@ -1,0 +1,43 @@
+# Aletheia_v3/core/mdl_synthesis/adapters.py
+import pickle
+from typing import Optional # Added Optional for type hinting if needed in future
+
+# Import ModelRepresentation from local entities
+from .entities import ModelRepresentation
+# Import ScientificConcept from its location in Aletheia_v3.core
+# Assuming Aletheia_v3 is in PYTHONPATH or relative imports work from this structure
+from ...core.domain_models import ScientificConcept, ConceptType
+
+def map_concept_to_representation(concept: ScientificConcept) -> ModelRepresentation:
+    """
+    Converts an Aletheia_v3 ScientificConcept into a ModelRepresentation
+    suitable for the MDL optimization engine.
+    """
+
+    model_content_dict = {
+        "id": str(concept.id), # Ensure string representation if id is UUID
+        "name": concept.name,
+        "description": concept.description,
+        # Ensure concept_type.value is used if concept_type is an Enum
+        "concept_type": concept.concept_type.value if isinstance(concept.concept_type, ConceptType) else str(concept.concept_type),
+        "properties": concept.properties,
+        # Consider adding embeddings if they are directly on the concept or in properties
+        # "embedding": concept.embedding_vector if hasattr(concept, 'embedding_vector') else None
+    }
+
+    # Serialize this dictionary to bytes using pickle
+    serialized_content: bytes = pickle.dumps(model_content_dict)
+
+    representation_identifier = str(concept.id)
+
+    return ModelRepresentation(
+        identifier=representation_identifier,
+        content=serialized_content
+    )
+
+# Example of a reverse function (conceptual, may not be needed for MDL optimization itself, for testing)
+def deserialize_model_representation_content(representation: ModelRepresentation) -> dict:
+    """Deserializes the content of ModelRepresentation back to a dictionary."""
+    if representation.content:
+        return pickle.loads(representation.content)
+    return {}

--- a/Aletheia_v3/core/mdl_synthesis/entities.py
+++ b/Aletheia_v3/core/mdl_synthesis/entities.py
@@ -1,0 +1,40 @@
+# Aletheia_v3/core/mdl_synthesis/entities.py
+from typing import Any, Dict # Changed from dict to Dict for consistency with Pydantic type hints
+from pydantic import BaseModel, Field as PydanticField
+
+class ModelRepresentation(BaseModel):
+    """
+    Representa un modelo algorítmicamente descriptible (M) del espacio M_S.
+    Su contenido puede ser cualquier objeto serializable que represente el modelo.
+    """
+    identifier: str = PydanticField(
+        ..., description="Un identificador único para el modelo, ej: 'Polynomial_Deg3'."
+    )
+    content: bytes = PydanticField(
+        ..., description="La representación serializada del modelo (ej. pickle, JSON)."
+    )
+
+    class Config:
+        frozen = True
+
+
+class ModelMetrics(BaseModel):
+    """
+    Almacena las métricas calculadas para un único modelo, incluyendo el coste MDL.
+    """
+    complexity: float = PydanticField(..., description="Proxy de la Complejidad de Kolmogorov, K(M).")
+    log_likelihood: float = PydanticField(..., description="Log-verosimilitud del modelo dados los datos, L(D|M).")
+    mdl_cost: float = PydanticField(..., description="Coste total según el Principio de Mínima Descripción (MDL).")
+
+    class Config:
+        frozen = True
+
+
+class OptimizationResult(BaseModel):
+    """
+    Encapsula el resultado de una ejecución del FindOptimalModelUseCase.
+    """
+    best_model: ModelRepresentation
+    best_model_metrics: ModelMetrics
+    search_space_size: int
+    parameters: Dict[str, Any] # Changed from dict to Dict

--- a/Aletheia_v3/core/mdl_synthesis/services.py
+++ b/Aletheia_v3/core/mdl_synthesis/services.py
@@ -1,0 +1,82 @@
+# Aletheia_v3/core/mdl_synthesis/services.py
+import gzip
+import pickle
+import random # For placeholder LikelihoodService
+import logging # For placeholder LikelihoodService
+from typing import Any
+
+# Import ModelRepresentation from the local entities.py
+from .entities import ModelRepresentation
+
+logger = logging.getLogger(__name__)
+
+class KolmogorovComplexityProxyService:
+    """
+    Servicio de dominio para calcular un proxy de la Complejidad de Kolmogorov.
+    La verdadera K(M) es incomputable. Usamos la longitud de la descripción
+    comprimida como una aproximación práctica y efectiva.
+    """
+
+    def compute(self, model_content: bytes) -> float:
+        """
+        Calcula la complejidad de un modelo como la longitud de su representación
+        serializada y comprimida con gzip.
+
+        @equations:
+            K_L(M) ≈ length(compress(describe(M, L)))
+            Donde L es Python (via pickle) y compress es gzip.
+
+        @param model_content: El contenido serializado del modelo.
+        @return: Un valor de complejidad no negativo.
+        """
+        if not model_content:
+            return 0.0
+        compressed_content = gzip.compress(model_content)
+        return float(len(compressed_content))
+
+
+class LikelihoodService:
+    """
+    Servicio de dominio para calcular la log-verosimilitud de un modelo
+    dado un conjunto de datos. La implementación específica depende del tipo de modelo
+    y de los datos.
+    """
+
+    def compute(self, model_representation: ModelRepresentation, data: Any) -> float:
+        """
+        Calcula la log-verosimilitud L(Data|Model).
+        Esta es una implementación placeholder y debe ser reemplazada con lógica real.
+        """
+        # model_content = model_representation.content # Access content if needed for future real impl
+        logger.warning(
+            "LikelihoodService.compute no está implementado con lógica real. "
+            "Devolviendo un valor aleatorio."
+        )
+        # Simula un log-likelihood, que es típicamente negativo o cero.
+        return random.uniform(-50.0, -1.0) # Adjusted range to be more typical for log-likelihoods
+
+
+class OmegaCostService:
+    """
+    Implementa el núcleo del Axioma 1 del modelo Ω: el Principio de Mínima Descripción.
+    """
+
+    def calculate_mdl_cost(
+        self, complexity: float, log_likelihood: float, lambda_param: float
+    ) -> float:
+        """
+        Calcula el coste total de un modelo. El objetivo es minimizar este coste.
+
+        @equations:
+            Cost(M) = λ * K(M) - L(D|M)
+
+        @param complexity: La complejidad calculada del modelo, K(M).
+        @param log_likelihood: La log-verosimilitud del modelo, L(D|M).
+        @param lambda_param: El parámetro de regularización λ, que balancea
+                             simplicidad vs. precisión.
+        @return: El coste MDL del modelo.
+        """
+        if lambda_param < 0:
+            raise ValueError("El parámetro de regularización λ no puede ser negativo.")
+
+        return (lambda_param * complexity) - log_likelihood

--- a/Aletheia_v3/requirements.txt
+++ b/Aletheia_v3/requirements.txt
@@ -11,6 +11,7 @@ redis[hiredis]>=4.0.0 # For Celery broker and backend
 scikit-optimize>=0.9.0 # For Bayesian Optimization
 numpy>=1.20.0 # Often a dependency of scikit-optimize, good to have explicit
 pandas>=1.3.0 # For data handling, used in dashboard
+scikit-learn>=1.0.0 # For ML utilities, potentially in LikelihoodService
 
 # Dashboard
 streamlit>=1.25.0

--- a/Aletheia_v3/tests/core/mdl_synthesis/__init__.py
+++ b/Aletheia_v3/tests/core/mdl_synthesis/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'mdl_synthesis' a test package

--- a/Aletheia_v3/tests/core/mdl_synthesis/test_adapters.py
+++ b/Aletheia_v3/tests/core/mdl_synthesis/test_adapters.py
@@ -1,0 +1,71 @@
+# Aletheia_v3/tests/core/mdl_synthesis/test_adapters.py
+import unittest
+import pickle
+import uuid
+
+# Import the function to test
+from Aletheia_v3.core.mdl_synthesis.adapters import map_concept_to_representation, deserialize_model_representation_content
+# Import the necessary domain models
+from Aletheia_v3.core.domain_models import ScientificConcept, ConceptType
+from Aletheia_v3.core.mdl_synthesis.entities import ModelRepresentation
+
+class TestAdapters(unittest.TestCase):
+
+    def test_map_concept_to_representation_and_deserialize(self):
+        # 1. Create a sample ScientificConcept
+        concept_id = uuid.uuid4()
+        sample_concept = ScientificConcept(
+            id=concept_id,
+            name="Test Cluster Alpha",
+            description="A sample cluster for testing MDL adapter.",
+            concept_type=ConceptType.CLUSTER,
+            properties={
+                "member_ucm_ids": ["ucm1", "ucm2", "ucm3"],
+                "shared_keywords": ["test", "mdl", "cluster"],
+                "embedding": [0.1, 0.2, 0.3] # Example embedding
+            },
+            # created_at and updated_at will have default values
+        )
+
+        # 2. Call the adapter
+        model_repr = map_concept_to_representation(sample_concept)
+
+        # 3. Verify the ModelRepresentation output
+        self.assertIsInstance(model_repr, ModelRepresentation)
+        self.assertEqual(model_repr.identifier, str(concept_id))
+        self.assertIsInstance(model_repr.content, bytes)
+
+        # 4. Deserialize the content and verify its structure and values
+        deserialized_content = deserialize_model_representation_content(model_repr)
+
+        self.assertIsInstance(deserialized_content, dict)
+        self.assertEqual(deserialized_content.get("id"), str(concept_id))
+        self.assertEqual(deserialized_content.get("name"), "Test Cluster Alpha")
+        self.assertEqual(deserialized_content.get("description"), "A sample cluster for testing MDL adapter.")
+        self.assertEqual(deserialized_content.get("concept_type"), ConceptType.CLUSTER.value)
+
+        properties = deserialized_content.get("properties")
+        self.assertIsInstance(properties, dict)
+        self.assertEqual(properties.get("member_ucm_ids"), ["ucm1", "ucm2", "ucm3"])
+        self.assertEqual(properties.get("shared_keywords"), ["test", "mdl", "cluster"])
+        self.assertEqual(properties.get("embedding"), [0.1, 0.2, 0.3])
+
+    def test_map_concept_with_minimal_data(self):
+        concept_id = uuid.uuid4()
+        sample_concept = ScientificConcept(
+            id=concept_id,
+            name="Minimal Concept",
+            concept_type=ConceptType.UCM
+            # No description, minimal properties
+        )
+        model_repr = map_concept_to_representation(sample_concept)
+        self.assertEqual(model_repr.identifier, str(concept_id))
+
+        deserialized_content = deserialize_model_representation_content(model_repr)
+        self.assertEqual(deserialized_content.get("name"), "Minimal Concept")
+        self.assertIsNone(deserialized_content.get("description")) # Or check against ScientificConcept's default
+        self.assertEqual(deserialized_content.get("concept_type"), ConceptType.UCM.value)
+        self.assertEqual(deserialized_content.get("properties"), {}) # Default from ScientificConcept
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Aletheia_v3/tests/core/mdl_synthesis/test_services.py
+++ b/Aletheia_v3/tests/core/mdl_synthesis/test_services.py
@@ -1,0 +1,84 @@
+# Aletheia_v3/tests/core/mdl_synthesis/test_services.py
+import unittest
+import gzip
+import pickle
+import logging
+from unittest.mock import patch, MagicMock
+
+# Import services to test
+from Aletheia_v3.core.mdl_synthesis.services import (
+    KolmogorovComplexityProxyService,
+    LikelihoodService,
+    OmegaCostService
+)
+# Import entities needed for tests
+from Aletheia_v3.core.mdl_synthesis.entities import ModelRepresentation
+
+class TestMDLServices(unittest.TestCase):
+
+    def setUp(self):
+        self.complexity_service = KolmogorovComplexityProxyService()
+        self.omega_cost_service = OmegaCostService()
+        self.likelihood_service = LikelihoodService() # Placeholder service
+
+    def test_kolmogorov_complexity_proxy_service(self):
+        # Test with some simple content
+        model_obj = {"param1": "value1", "param2": [1, 2, 3]}
+        model_content_bytes = pickle.dumps(model_obj)
+
+        complexity = self.complexity_service.compute(model_content_bytes)
+        self.assertIsInstance(complexity, float)
+        self.assertGreaterEqual(complexity, 0)
+
+        # Expected length of gzipped pickled content
+        expected_complexity = float(len(gzip.compress(model_content_bytes)))
+        self.assertEqual(complexity, expected_complexity)
+
+        # Test with empty content
+        empty_complexity = self.complexity_service.compute(b"")
+        self.assertEqual(empty_complexity, 0.0)
+
+    def test_omega_cost_service(self):
+        complexity = 50.0
+        log_likelihood = -15.0
+        lambda_param = 1.0
+
+        mdl_cost = self.omega_cost_service.calculate_mdl_cost(complexity, log_likelihood, lambda_param)
+        # Expected: Cost(M) = λ * K(M) - L(D|M) = 1.0 * 50.0 - (-15.0) = 50.0 + 15.0 = 65.0
+        self.assertEqual(mdl_cost, 65.0)
+
+        lambda_param_zero = 0.0
+        mdl_cost_lambda_zero = self.omega_cost_service.calculate_mdl_cost(complexity, log_likelihood, lambda_param_zero)
+        # Expected: 0.0 * 50.0 - (-15.0) = 15.0
+        self.assertEqual(mdl_cost_lambda_zero, 15.0)
+
+        # Test with negative lambda (should raise ValueError)
+        with self.assertRaises(ValueError):
+            self.omega_cost_service.calculate_mdl_cost(complexity, log_likelihood, -0.5)
+
+    def test_likelihood_service_placeholder(self):
+        # Create a dummy ModelRepresentation and data
+        # The content of these doesn't matter for the placeholder
+        dummy_model_repr = ModelRepresentation(identifier="test_model", content=b"dummy_content")
+        dummy_data = {"x": [1,2], "y": [3,4]}
+
+        # Mock the logger used within LikelihoodService
+        # The logger is obtained by logging.getLogger(__name__) where __name__ is the module name.
+        # So, we need to patch 'Aletheia_v3.core.mdl_synthesis.services.logger.warning'
+        with patch('Aletheia_v3.core.mdl_synthesis.services.logger.warning') as mock_log_warning:
+            likelihood_value = self.likelihood_service.compute(dummy_model_repr, dummy_data)
+
+            # Verify it returns a float
+            self.assertIsInstance(likelihood_value, float)
+            # Verify it's within the specified random range for the placeholder
+            self.assertTrue(-50.0 <= likelihood_value <= -1.0) # Adjusted based on service impl.
+
+            # Verify that the warning was logged
+            mock_log_warning.assert_called_once()
+            # Check if the log message contains the expected text
+            args, _ = mock_log_warning.call_args
+            self.assertIn("LikelihoodService.compute no está implementado con lógica real.", args[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Created directory structure Aletheia_v3/core/mdl_synthesis/.
- Implemented MDL entities (ModelRepresentation, ModelMetrics, OptimizationResult) in core/mdl_synthesis/entities.py.
- Implemented MDL services in core/mdl_synthesis/services.py:
    - Copied KolmogorovComplexityProxyService and OmegaCostService.
    - Added placeholder LikelihoodService.
- Implemented ScientificConcept to ModelRepresentation adapter in core/mdl_synthesis/adapters.py.
- Adapted FindOptimalModelUseCase to application/mdl_synthesis_use_cases.py.
- Added scikit-learn to Aletheia_v3/requirements.txt.
- Created unit tests for the new adapter and services.

This lays the foundation for integrating MDL-based optimization into Aletheia_v3's knowledge synthesis pipeline.