### PR TITLE
Refactor FormClustersUseCase to use MDL engine

### DIFF
--- a/Aletheia_v3/api/dependencies.py
+++ b/Aletheia_v3/api/dependencies.py
@@ -48,6 +48,15 @@ from .schemas import (
     UnifiedModelsInputSchema, UnifiedModelsResultSchema
 )
 
+# MDL Synthesis components
+from ..core.mdl_synthesis.services import (
+    KolmogorovComplexityProxyService,
+    LikelihoodService,
+    OmegaCostService
+)
+from ..application.mdl_synthesis_use_cases import FindOptimalModelUseCase
+
+
 # Infraestructura (Trackers, Queues, Monitoring - Implementaciones directas o mocks simples)
 from ..infrastructure.monitoring import CubeMonitoring
 
@@ -151,10 +160,42 @@ def get_link_concepts_use_case(
 
 # Eje Y (Actualizado para usar implementaciones reales)
 
+# --- MDL Synthesis Service Providers ---
+@lru_cache(None)
+def get_kolmogorov_complexity_proxy_service() -> KolmogorovComplexityProxyService:
+    return KolmogorovComplexityProxyService()
+
+@lru_cache(None)
+def get_likelihood_service() -> LikelihoodService:
+    # This will provide the placeholder LikelihoodService for now
+    return LikelihoodService()
+
+@lru_cache(None)
+def get_omega_cost_service() -> OmegaCostService:
+    return OmegaCostService()
+
+# --- MDL Synthesis Use Case Provider ---
+@lru_cache(None)
+def get_find_optimal_model_use_case(
+    complexity_service: KolmogorovComplexityProxyService = Depends(get_kolmogorov_complexity_proxy_service),
+    likelihood_service: LikelihoodService = Depends(get_likelihood_service),
+    omega_cost_service: OmegaCostService = Depends(get_omega_cost_service)
+) -> FindOptimalModelUseCase:
+    return FindOptimalModelUseCase(
+        complexity_service=complexity_service,
+        likelihood_service=likelihood_service,
+        omega_cost_service=omega_cost_service
+    )
+
+# --- Eje Y Use Case Providers (Updated) ---
 def get_form_clusters_use_case(
-    concept_repo: IConceptRepository = Depends(get_concept_repository)
+    concept_repo: IConceptRepository = Depends(get_concept_repository),
+    find_optimal_model_uc: FindOptimalModelUseCase = Depends(get_find_optimal_model_use_case)
 ) -> FormClustersUseCase:
-    return FormClustersUseCase(concept_repo=concept_repo)
+    return FormClustersUseCase(
+        concept_repo=concept_repo,
+        find_optimal_model_uc=find_optimal_model_uc
+    )
 
 def get_derive_propositions_use_case( # Nombre de función actualizado
     concept_repo: IConceptRepository = Depends(get_concept_repository)

--- a/Aletheia_v3/application/use_cases.py
+++ b/Aletheia_v3/application/use_cases.py
@@ -910,13 +910,21 @@ MIN_COMMON_KEYWORDS_FOR_CLUSTER = 2
 
 
 class FormClustersUseCase: # Reemplaza el Protocol
-    """
-    Caso de uso para formar clústeres de conceptos (UCMs) basados en palabras clave compartidas.
-    """
-    def __init__(self, concept_repo: IConceptRepository):
-        self.concept_repo = concept_repo
+# Import FindOptimalModelUseCase for dependency injection
+from .mdl_synthesis_use_cases import FindOptimalModelUseCase
 
-    def _extract_keywords(self, text: Optional[str]) -> Set[str]:
+class FormClustersUseCase: # Reemplaza el Protocol
+    """
+    Caso de uso para formar clústeres de conceptos (UCMs).
+    Refactorizado para usar FindOptimalModelUseCase para seleccionar el mejor clustering.
+    """
+    def __init__(self,
+                 concept_repo: IConceptRepository,
+                 find_optimal_model_uc: FindOptimalModelUseCase):
+        self.concept_repo = concept_repo
+        self.find_optimal_model_uc = find_optimal_model_uc
+
+    def _extract_keywords(self, text: Optional[str]) -> Set[str]: # This method might become obsolete or change
         if not text:
             return set()
         # Tokenización simple y eliminación de stopwords


### PR DESCRIPTION
- Updated FormClustersUseCase to inject FindOptimalModelUseCase.
- Modified FormClustersUseCase.execute:
    - Generates candidate clusters using AgglomerativeClustering on UCM embeddings.
    - Maps candidates to ModelRepresentation.
    - Uses FindOptimalModelUseCase to select the best cluster based on MDL.
    - Persists only the winning cluster.
- Implemented LikelihoodService.compute for clusters:
    - Calculates cohesion based on average intra-cluster cosine similarity of UCM embeddings.
    - Returns log(cohesion_score + epsilon).
- Updated API dependencies to provide MDL services and use cases.
- Added unit tests for the refactored FormClustersUseCase, mocking dependencies and verifying interactions.
- Added unit tests for the new cluster-specific LikelihoodService logic.