### PR TITLE
Refactor MiniTheoryConstructionUseCase to use MDL engine

### DIFF
--- a/Aletheia_v3/api/dependencies.py
+++ b/Aletheia_v3/api/dependencies.py
@@ -207,9 +207,13 @@ def get_derive_propositions_use_case(
     )
 
 def get_mini_theory_construction_use_case(
-    concept_repo: IConceptRepository = Depends(get_concept_repository)
+    concept_repo: IConceptRepository = Depends(get_concept_repository),
+    find_optimal_model_uc: FindOptimalModelUseCase = Depends(get_find_optimal_model_use_case)
 ) -> MiniTheoryConstructionUseCase:
-    return MiniTheoryConstructionUseCase(concept_repo=concept_repo)
+    return MiniTheoryConstructionUseCase(
+        concept_repo=concept_repo,
+        find_optimal_model_uc=find_optimal_model_uc
+    )
 
 def get_comprehensive_theories_use_case(
     concept_repo: IConceptRepository = Depends(get_concept_repository)

--- a/Aletheia_v3/application/use_cases.py
+++ b/Aletheia_v3/application/use_cases.py
@@ -1200,9 +1200,13 @@ class DerivePropositionsUseCase: # Nombre actualizado y reemplaza Protocol
 class MiniTheoryConstructionUseCase: # Reemplaza Protocol
     """
     Caso de uso para construir una mini-teoría a partir de un conjunto de proposiciones.
+    Refactorizado para usar FindOptimalModelUseCase.
     """
-    def __init__(self, concept_repo: IConceptRepository):
+    def __init__(self,
+                 concept_repo: IConceptRepository,
+                 find_optimal_model_uc: FindOptimalModelUseCase): # Added dependency
         self.concept_repo = concept_repo
+        self.find_optimal_model_uc = find_optimal_model_uc # Store dependency
 
     async def execute(self, input_data: MiniTheoryConstructionInputSchema) -> MiniTheoryConstructionResultSchema:
         """


### PR DESCRIPTION
- Updated MiniTheoryConstructionUseCase to inject and use FindOptimalModelUseCase.
- Modified MiniTheoryConstructionUseCase.execute:
    - Loads input propositions.
    - Generates candidate mini-theories (full set, subset, alternative description) with placeholder embeddings.
    - Maps candidates to ModelRepresentation.
    - Uses FindOptimalModelUseCase to select the best mini-theory.
    - Persists only the winning mini-theory.
- Implemented LikelihoodService.compute for mini-theories:
    - Calculates likelihood based on a weighted score of coverage (proportion of input propositions included) and coherence (average cosine similarity of member proposition embeddings).
    - Returns log(score + epsilon).
- Updated API dependencies for MiniTheoryConstructionUseCase.
- Added unit tests for the refactored MiniTheoryConstructionUseCase.
- Added unit tests for the new mini-theory specific LikelihoodService logic.