### PR TITLE
Fix: Move license to root and fix mermaid diagrams

### DIFF
--- a/aletheia_common/README.md
+++ b/aletheia_common/README.md
@@ -47,6 +47,7 @@ graph TD
     style O fill:#e8dff5
     style S fill:#fcf6bd
 ```
+</details>
 
 ## Cumplimiento del MDU
 


### PR DESCRIPTION
I've moved the LICENSE file from Aletheia_v3/ to the root directory.

I also wrapped all mermaid diagrams in `<details>` tags to ensure they render correctly in markdown viewers.